### PR TITLE
fix: functional audit round 4 — Zhihuishu API signing, CORS order, sign-in robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ backend/cache.json
 # Claude Code worktree metadata (per-machine, not project source)
 .claude/
 
+frontend/coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (round 4 — functional audit, validated against real 学习通/知到 accounts)
+- **Zhihuishu course/video listing was fully broken** — Zhihuishu's `AppInterfaceSignInterceptor` now rejects unsigned requests (`code:400 "aes加密参数异常"`), so `get_course_list`/`get_video_list` returned empty. Requests are now AES-signed via the new `crypto.encrypt_secret_str()` (`secretStr` param + `HOME_KEY`) and read the response under `result` (the server moved it from `rt`). Verified live (request accepted, code 200). *(studyservice/video-list key still needs a real enrolled course to confirm.)*
+- **CORS middleware order** — `CORSMiddleware` is now outermost so `tenant_isolation`'s 401 carries `Access-Control-Allow-Origin`; the SPA's session-expiry redirect fires instead of the app appearing to hang. (Supersedes the round-3 "metrics first-registered" note, which had the nesting backwards; metrics now sits outside tenant_isolation so it still counts those 401s.)
+- **Chaoxing sign-in robustness** — activity-list `"data": null` no longer raises `AttributeError`; `int(None)` on `otherId/status/ifphoto` is coerced; one course's transient activity-list error no longer aborts the whole sign-in batch.
+- **Chaoxing chapter progress** now reaches 100% for courses with pre-finished chapters (the done-callback fires on the already-finished early-return path).
+- **Chaoxing sign-in task logs** use a stateless client-supplied cursor (was a destructive shared server cursor that blanked logs on reopen / overlapping polls).
+- **Zhihuishu video watching** honors the configured speed and reacts to pause/cancel mid-video; a 0/None-duration video is surfaced as failed instead of fake-completed.
+- **Zhihuishu QR refresh** — the QR regenerated after expiry is now delivered through the login-status poll and re-rendered.
+- **Zhihuishu auto-answer** no longer silently discards the computed answer (logs that platform submission is not yet implemented).
+- **Font-map resource path** resolves package-relative (was CWD-relative → wrong directory); a shipped `resource/font_map_table.json` is now found regardless of process CWD.
+- **Answer-title OCR** gate now triggers for any OCR backend (external vision / HTTP endpoint), not only local Paddle OCR.
+- **Rate limiter** DB round-trip on `/auth/login` and `/auth/register` is offloaded via `asyncio.to_thread` so it no longer blocks the async event loop.
+
 ### Added (round 3 — architectural foundations for previously-deferred items)
 - **PWA** via `vite-plugin-pwa` — service worker + precache for hashed static assets, `NetworkOnly` policy for `/api/*` to keep tenant-scoped data uncached; build produces `dist/sw.js` and `dist/workbox-*.js`.
 - **TypeScript foundation** — `frontend/tsconfig.json` with `allowJs: true`, strict mode, path alias `@/*`. New modules can be `.ts`/`.tsx`; existing `.jsx` keeps compiling unchanged. Shared API contract typings live in `frontend/src/types/api.d.ts`.

--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -1,9 +1,11 @@
+import asyncio
+import logging
+
 from fastapi import APIRouter, HTTPException, status, Request, Depends
 from app.schemas.auth import LoginRequest, RegisterRequest, TokenResponse
 from app.services.auth_service import AuthService
 from app.middleware.rate_limiter import rate_limiter
 from app.dependencies import get_current_user
-import logging
 
 router = APIRouter()
 auth_service = AuthService()
@@ -27,7 +29,9 @@ def _mask_email(email: str) -> str:
 # ValueError -> 400 with the (user-facing, non-sensitive) validation message.
 @router.post("/register", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)
 async def register(request: RegisterRequest, req: Request):
-    rate_limiter.check_rate_limit(req)
+    # Offload the rate limiter's blocking psycopg2 round-trip so it does not
+    # stall the single uvicorn event loop; a raised HTTPException propagates back.
+    await asyncio.to_thread(rate_limiter.check_rate_limit, req)
     try:
         result = await auth_service.register_user(
             username=request.username,
@@ -45,7 +49,7 @@ async def register(request: RegisterRequest, req: Request):
 
 @router.post("/login", response_model=TokenResponse)
 async def login(request: LoginRequest, req: Request):
-    rate_limiter.check_rate_limit(req)
+    await asyncio.to_thread(rate_limiter.check_rate_limit, req)
     try:
         result = await auth_service.login_user(
             email=request.email,

--- a/backend/app/api/v1/chaoxing.py
+++ b/backend/app/api/v1/chaoxing.py
@@ -656,10 +656,19 @@ async def chaoxing_task(task_id: str, user_id: str = Depends(get_current_user_id
 
 
 @router.get("/logs/{task_id}")
-async def chaoxing_logs(task_id: str, user_id: str = Depends(get_current_user_id)):
-    logs = await _run_blocking(
-        signin_manager.get_task_logs, user_id=user_id, task_id=task_id
+async def chaoxing_logs(
+    task_id: str,
+    cursor: Optional[int] = None,
+    user_id: str = Depends(get_current_user_id),
+):
+    log_state = await _run_blocking(
+        signin_manager.get_task_logs, user_id=user_id, task_id=task_id, cursor=cursor
     )
-    if logs is None:
+    if log_state is None:
         raise HTTPException(status_code=404, detail="Task not found")
-    return {"status": True, "message": "ok", "data": logs}
+    return {
+        "status": True,
+        "message": "ok",
+        "data": log_state.get("logs", []),
+        "cursor": log_state.get("cursor", 0),
+    }

--- a/backend/app/api/v1/course.py
+++ b/backend/app/api/v1/course.py
@@ -60,6 +60,10 @@ class ZhihuishuQRStatusResponse(BaseModel):
     session_id: str
     status: str
     message: str
+    # Carry the (possibly refreshed) QR image so the client can re-render it when
+    # the original expires — qr_login regenerates the QR on expiry, but without
+    # this field the poller never sees the new code. (F-qr-refresh)
+    qr_code: Optional[str] = None
 
 
 class ZhihuishuPasswordLoginRequest(BaseModel):
@@ -477,6 +481,7 @@ async def get_zhihuishu_login_status(
             session_id=session_id,
             status=state.get("status", "pending"),
             message=state.get("message", "Waiting for scan"),
+            qr_code=state.get("qr_code"),
         )
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -89,10 +89,21 @@ def _build_allowed_hosts(origins: list[str]) -> list[str]:
 
 
 # NOTE on middleware ordering:
-# FastAPI runs `@app.middleware("http")` and `add_middleware` in REVERSE
-# registration order — the LAST registered is the OUTERMOST. Register
-# request_metrics_middleware FIRST so it wraps everything else and sees
-# 401s emitted by tenant_isolation/CORS.
+# Starlette runs middleware in REVERSE registration order — the LAST registered
+# is the OUTERMOST. We need, from outer to inner:
+#     CORS -> TrustedHost -> security_headers -> https_redirect -> metrics -> tenant_isolation -> route
+# so that (a) CORS is outermost and wraps EVERY response — including the bare 401
+# that tenant_isolation short-circuits on a missing/expired token — giving it the
+# Access-Control-Allow-Origin header so the browser can READ the 401 and the SPA's
+# 401 handler fires (otherwise session-expiry looks like a hung app); and (b)
+# request_metrics sits OUTSIDE tenant_isolation so it still counts those 401s.
+# Therefore tenant_isolation is registered FIRST (innermost) and CORS LAST.
+
+# Innermost middleware: registered first so its short-circuit responses still
+# travel back out through request_metrics (counted) and CORS (CORS headers added).
+app.middleware("http")(tenant_isolation_middleware)
+
+
 @app.middleware("http")
 async def request_metrics_middleware(request: Request, call_next):
     response = await call_next(request)
@@ -148,9 +159,8 @@ app.add_middleware(
     allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allow_headers=["Authorization", "Content-Type"],
 )
-
-# Tenant isolation middleware
-app.middleware("http")(tenant_isolation_middleware)
+# (tenant_isolation_middleware is registered ABOVE as the innermost middleware so
+# its short-circuit 401 still passes back out through CORS — see the ordering note.)
 
 
 # Global exception handlers

--- a/backend/app/middleware/rate_limiter.py
+++ b/backend/app/middleware/rate_limiter.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 from ipaddress import ip_address
 
 from fastapi import Request, HTTPException, status
@@ -19,6 +20,11 @@ class RateLimiter:
         self.window = window
         self._cache: Dict[str, Tuple[int, datetime]] = defaultdict(lambda: (0, datetime.now()))
         self._request_count: int = 0
+        # check_rate_limit is now invoked via asyncio.to_thread (off the event
+        # loop), so concurrent threads can touch _cache / _request_count at once.
+        # Guard every mutation of that shared state to avoid lost counts and
+        # "dict changed size during iteration" in the cleanup sweep.
+        self._lock = threading.Lock()
 
     def _is_trusted_proxy(self, host: str) -> bool:
         candidate = str(host or "").strip()
@@ -56,10 +62,11 @@ class RateLimiter:
 
     def _maybe_cleanup(self) -> None:
         """Periodically clean up expired and excess entries."""
-        self._request_count += 1
-        if self._request_count % self.CLEANUP_INTERVAL == 0:
-            self._cleanup_expired()
-            self._evict_oldest()
+        with self._lock:
+            self._request_count += 1
+            if self._request_count % self.CLEANUP_INTERVAL == 0:
+                self._cleanup_expired()
+                self._evict_oldest()
 
     def _get_forwarded_client_id(self, request: Request) -> Optional[str]:
         # X-Forwarded-For is only consulted when the direct peer is a known
@@ -155,17 +162,18 @@ class RateLimiter:
 
     def _check_in_memory(self, client_id: str, now: datetime) -> bool:
         """In-memory fallback. Returns True if allowed, False if blocked."""
-        count, start_time = self._cache[client_id]
+        with self._lock:
+            count, start_time = self._cache[client_id]
 
-        if now - start_time > timedelta(seconds=self.window):
-            self._cache[client_id] = (1, now)
+            if now - start_time > timedelta(seconds=self.window):
+                self._cache[client_id] = (1, now)
+                return True
+
+            if count >= self.requests:
+                return False
+
+            self._cache[client_id] = (count + 1, start_time)
             return True
-
-        if count >= self.requests:
-            return False
-
-        self._cache[client_id] = (count + 1, start_time)
-        return True
 
     def check_rate_limit(self, request: Request) -> None:
         self._maybe_cleanup()

--- a/backend/app/services/course/chaoxing/answer_utils.py
+++ b/backend/app/services/course/chaoxing/answer_utils.py
@@ -1,7 +1,21 @@
+import os
 import re
 
-from .decode import _ocr_image_to_text, ENABLE_LOCAL_OCR
+from .decode import _ocr_image_to_text, ENABLE_LOCAL_OCR, is_vision_ocr_enabled
 from loguru import logger
+
+
+def _has_any_ocr_backend() -> bool:
+    """True if ANY OCR backend is usable (local Paddle, external vision, or HTTP).
+
+    Mirrors decode._ocr_image_to_text's `has_any_ocr` gate so question-title OCR
+    is applied whenever it can succeed — not only when LOCAL OCR is on.
+    """
+    return bool(
+        ENABLE_LOCAL_OCR
+        or is_vision_ocr_enabled()
+        or os.environ.get("CHAOXING_OCR_ENDPOINT", "").strip()
+    )
 
 
 def _strip_json_block(md_str: str) -> str:
@@ -53,7 +67,7 @@ def _apply_ocr_to_title_if_needed(q_info: dict) -> None:
     仅处理作业题目的标题字符串，不影响其他阅读类内容；
     当 OCR 不可用或识别失败时，不修改原始标题。
     """
-    if not ENABLE_LOCAL_OCR:
+    if not _has_any_ocr_backend():
         return
 
     title = q_info.get("title")

--- a/backend/app/services/course/chaoxing/cxsecret_font.py
+++ b/backend/app/services/course/chaoxing/cxsecret_font.py
@@ -30,7 +30,14 @@ KX_RADICALS_TAB = str.maketrans(
 
 def resource_path(relative_path: str) -> str:
     """
-    获取资源文件的路径，兼容PyInstaller打包后的环境
+    获取资源文件的路径，兼容PyInstaller打包后的环境。
+
+    解析顺序（返回第一个真实存在的候选，否则回退到稳定的 backend 根目录候选）：
+      1. PyInstaller 临时目录 (sys._MEIPASS)
+      2. backend 根目录（由本文件位置推导，与进程 CWD 无关）—— 生产环境
+         uvicorn 的 CWD 不一定是 backend，旧实现用 os.path.abspath(".")
+         会解析到错误目录导致即便已放置 resource/ 也找不到。(audit F14)
+      3. 进程当前工作目录
 
     Args:
         relative_path: 相对路径
@@ -38,14 +45,22 @@ def resource_path(relative_path: str) -> str:
     Returns:
         资源文件的绝对路径
     """
-    try:
-        # PyInstaller创建临时文件夹，定位路径
-        base_path = sys._MEIPASS
-    except Exception:
-        # 非打包环境，使用当前目录
-        base_path = os.path.abspath(".")
-    
-    return os.path.join(base_path, relative_path)
+    candidates = []
+    meipass = getattr(sys, "_MEIPASS", None)
+    if meipass:
+        candidates.append(os.path.join(meipass, relative_path))
+    # .../backend/app/services/course/chaoxing/cxsecret_font.py -> parents[4] == backend
+    backend_root = Path(__file__).resolve().parents[4]
+    backend_candidate = str(backend_root / relative_path)
+    candidates.append(backend_candidate)
+    candidates.append(os.path.join(os.path.abspath("."), relative_path))
+
+    for candidate in candidates:
+        if os.path.exists(candidate):
+            return candidate
+    # Stable fallback independent of CWD so a shipped file is found even if cwd
+    # differs; if it is genuinely absent the caller degrades gracefully.
+    return backend_candidate
 
 
 class FontHashDAO:

--- a/backend/app/services/course/chaoxing/learning.py
+++ b/backend/app/services/course/chaoxing/learning.py
@@ -512,7 +512,17 @@ def process_chapter(chaoxing: Chaoxing, course:dict[str, Any], point:dict[str, A
                 logger.debug(f"调用 chapter_start_callback 时出错: {e}")
     if point["has_finished"]:
         logger.info(f'章节：{point["title"]} 已完成所有任务点')
-        # 已经在超星端标记为完成的章节，这里直接视为成功，但不再重复回调
+        # 该章节在超星端已标记完成：必须计入"已完成章节"统计。learning_manager
+        # 把所有章节(含已完成)都加进 total_chapters，而 completed_chapters 只在
+        # chapter_done_callback 里累加；若此处直接 return 而不回调，预先完成的章节
+        # 只进 total 不进 completed，进度条永远到不了 100%。(F-progress)
+        if config is not None:
+            done_cb = config.get("chapter_done_callback")
+            if callable(done_cb):
+                try:
+                    done_cb(course, point)
+                except Exception as e:
+                    logger.debug(f"调用 chapter_done_callback 时出错: {e}")
         return ChapterResult.SUCCESS
     
     # 随机等待，避免请求过快

--- a/backend/app/services/course/chaoxing/signin.py
+++ b/backend/app/services/course/chaoxing/signin.py
@@ -757,11 +757,12 @@ class ChaoxingSigninClient:
         return activities
 
     def _get_course_activity_list(self, course_id: str, class_id: str) -> List[Dict[str, Any]]:
-        # Raises requests.RequestException on network failure so callers can tell a
-        # transient fetch error apart from a genuinely empty activeList — returning
-        # [] for both would let a Chaoxing timeout look like a successful "no active
-        # sign-in" no-op. Callers guard PER COURSE so one bad course still does not
-        # abort the whole batch.
+        # Raises requests.RequestException on ANY fetch failure — network error,
+        # non-2xx HTTP (e.g. 502), OR a non-JSON body (e.g. an auth-redirect login
+        # page served as 200 HTML) — so callers can tell a transient/upstream
+        # failure apart from a genuinely empty activeList. Returning [] for all of
+        # them would let a failure look like a successful "no active sign-in" no-op.
+        # Callers guard PER COURSE so one bad course still does not abort the batch.
         resp = self.session.get(
             ACTIVE_LIST_URL,
             params={
@@ -772,7 +773,14 @@ class ChaoxingSigninClient:
             },
             timeout=12,
         )
-        data = self._safe_json(resp)
+        resp.raise_for_status()  # requests.HTTPError (a RequestException) on 4xx/5xx
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            # Not JSON → an error/redirect page, NOT an empty activeList.
+            raise requests.RequestException(
+                "activelist returned a non-JSON response"
+            ) from exc
         # `data.get("data", {})` does NOT guard an explicit ``"data": null`` (common
         # when a per-course session/cookie is invalid) — `None.get(...)` would raise
         # AttributeError and crash discovery; use `or {}`.

--- a/backend/app/services/course/chaoxing/signin.py
+++ b/backend/app/services/course/chaoxing/signin.py
@@ -647,7 +647,9 @@ class ChaoxingSigninClient:
 
             payload = self._get_course_activity_list(course_id, class_id)
             for activity in payload:
-                if int(activity.get("status", 0)) != 1:
+                # Chaoxing routinely sends keys present-but-null; `int(None)` would
+                # raise TypeError and abort the whole batch, so coerce with `or 0`.
+                if int(activity.get("status") or 0) != 1:
                     continue
                 activity_id = str(activity.get("id") or "")
                 if not activity_id:
@@ -728,18 +730,31 @@ class ChaoxingSigninClient:
         return activities
 
     def _get_course_activity_list(self, course_id: str, class_id: str) -> List[Dict[str, Any]]:
-        resp = self.session.get(
-            ACTIVE_LIST_URL,
-            params={
-                "fid": 0,
-                "courseId": course_id,
-                "classId": class_id,
-                "_": int(time.time() * 1000),
-            },
-            timeout=12,
-        )
+        # A network failure here must NOT abort discovery for the OTHER courses:
+        # return [] so the per-course loop skips this one (matches the guarded
+        # pattern used by every other network call in this client).
+        try:
+            resp = self.session.get(
+                ACTIVE_LIST_URL,
+                params={
+                    "fid": 0,
+                    "courseId": course_id,
+                    "classId": class_id,
+                    "_": int(time.time() * 1000),
+                },
+                timeout=12,
+            )
+        except requests.RequestException as exc:
+            logger.warning(
+                "activelist request failed for course=%s class=%s: %s",
+                course_id, class_id, exc,
+            )
+            return []
         data = self._safe_json(resp)
-        active_list = data.get("data", {}).get("activeList", [])
+        # `data.get("data", {})` does NOT guard an explicit ``"data": null`` (common
+        # when a per-course session/cookie is invalid) — `None.get(...)` would raise
+        # AttributeError and crash discovery; use `or {}`.
+        active_list = (data.get("data") or {}).get("activeList", [])
         return active_list if isinstance(active_list, list) else []
 
     def _resolve_sign_type(
@@ -748,7 +763,9 @@ class ChaoxingSigninClient:
         active_id: str,
         info: Optional[Dict[str, Any]] = None,
     ) -> str:
-        other_id = int(activity.get("otherId", 0))
+        # `or 0` (not the 2-arg .get default) so a present-but-null field — which
+        # Chaoxing sends routinely — does not raise TypeError on int(None).
+        other_id = int(activity.get("otherId") or 0)
         if other_id == 3:
             return "gesture"
         if other_id == 5:
@@ -758,10 +775,10 @@ class ChaoxingSigninClient:
         if other_id == 2:
             return "qrcode"
         if other_id == 0:
-            if int(activity.get("ifphoto", 0)) == 1:
+            if int(activity.get("ifphoto") or 0) == 1:
                 return "photo"
             info = info if info is not None else self.get_ppt_active_info(active_id)
-            if int(info.get("ifphoto", 0)) == 1:
+            if int((info or {}).get("ifphoto") or 0) == 1:
                 return "photo"
             return "normal"
         return "normal"
@@ -799,7 +816,7 @@ class ChaoxingSigninClient:
             "className": str(course.get("className") or course.get("clazzName") or course_name).strip(),
             "name": activity.get("nameOne") or activity.get("name") or "",
             "type": sign_type or self._resolve_sign_type(activity, active_id, detail),
-            "otherId": int(activity.get("otherId", 0)),
+            "otherId": int(activity.get("otherId") or 0),
             "status": "active" if status_code == 1 else "ended" if status_code in (2, 3) else "unknown",
             "statusCode": status_code,
             "deadline": deadline_iso,
@@ -1668,26 +1685,38 @@ class ChaoxingSigninManager:
             reverse=True,
         )
 
-    def get_task_logs(self, user_id: str, task_id: str) -> Optional[List[Dict[str, Any]]]:
+    def get_task_logs(
+        self, user_id: str, task_id: str, cursor: Optional[int] = None
+    ) -> Optional[Dict[str, Any]]:
+        """Return logs from ``cursor`` (default 0) WITHOUT mutating server state.
+
+        Stateless, per-request slicing — mirrors learning_manager.get_task_logs.
+        The old version advanced a single shared server-side cursor on every read,
+        so reopening a task or two overlapping polls (3s poll vs manual refresh)
+        raced on it and showed blank/partial logs. The client now tracks its own
+        cursor and passes it back.
+        """
         normalized_user_id = str(user_id or "").strip()
         normalized_task_id = str(task_id or "").strip()
+
+        def _slice(task: Dict[str, Any]) -> Dict[str, Any]:
+            all_logs = task.get("logs", [])
+            start = int(cursor) if cursor is not None else 0
+            if start < 0:
+                start = 0
+            return {"logs": list(all_logs[start:]), "cursor": len(all_logs)}
+
         with self._lock:
             task = self._tasks.get(normalized_task_id)
             if task and task.get("user_id") == normalized_user_id:
-                start = int(task.get("_log_cursor", 0))
-                logs = list(task.get("logs", [])[start:])
-                task["_log_cursor"] = len(task.get("logs", []))
-                return logs
+                return _slice(task)
 
         self._load_task_from_store(normalized_user_id, normalized_task_id)
         with self._lock:
             task = self._tasks.get(normalized_task_id)
             if not task or task.get("user_id") != normalized_user_id:
                 return None
-            start = int(task.get("_log_cursor", 0))
-            logs = list(task.get("logs", [])[start:])
-            task["_log_cursor"] = len(task.get("logs", []))
-            return logs
+            return _slice(task)
 
     @staticmethod
     def _task_public_payload(task: Dict[str, Any]) -> Dict[str, Any]:

--- a/backend/app/services/course/chaoxing/signin.py
+++ b/backend/app/services/course/chaoxing/signin.py
@@ -636,6 +636,8 @@ class ChaoxingSigninClient:
 
         tasks: List[Dict[str, Any]] = []
         now_ms = int(time.time() * 1000)
+        attempted = 0
+        failed = 0
 
         for course in courses:
             course_id = str(course.get("courseId", ""))
@@ -645,7 +647,16 @@ class ChaoxingSigninClient:
             if class_filter_set and class_id not in class_filter_set:
                 continue
 
-            payload = self._get_course_activity_list(course_id, class_id)
+            attempted += 1
+            try:
+                payload = self._get_course_activity_list(course_id, class_id)
+            except requests.RequestException as exc:
+                # One bad course must not abort the batch — skip it and keep going.
+                failed += 1
+                logger.warning(
+                    "activelist failed for course=%s class=%s: %s", course_id, class_id, exc
+                )
+                continue
             for activity in payload:
                 # Chaoxing routinely sends keys present-but-null; `int(None)` would
                 # raise TypeError and abort the whole batch, so coerce with `or 0`.
@@ -671,6 +682,14 @@ class ChaoxingSigninClient:
 
                 tasks.append(self._activity_to_task(course, activity, sign_type=sign_type))
 
+        # If EVERY course we tried failed to fetch, surface the upstream failure
+        # instead of an empty (== "no active sign-in") result that a caller would
+        # treat as a successful no-op. (Codex P2)
+        if attempted and failed == attempted and not tasks:
+            raise requests.RequestException(
+                f"All {attempted} activity-list request(s) failed; "
+                "cannot determine active sign-in tasks"
+            )
         return tasks
 
     def get_class_subjects(self) -> List[Dict[str, Any]]:
@@ -718,7 +737,15 @@ class ChaoxingSigninClient:
                 continue
             if normalized_raw_course_id and current_course_id != normalized_raw_course_id:
                 continue
-            for activity in self._get_course_activity_list(current_course_id, current_class_id):
+            try:
+                course_activity_list = self._get_course_activity_list(current_course_id, current_class_id)
+            except requests.RequestException as exc:
+                logger.warning(
+                    "activelist failed for course=%s class=%s: %s",
+                    current_course_id, current_class_id, exc,
+                )
+                continue
+            for activity in course_activity_list:
                 detail = {}
                 active_id = str(activity.get("id") or "").strip()
                 if include_details and active_id:
@@ -730,26 +757,21 @@ class ChaoxingSigninClient:
         return activities
 
     def _get_course_activity_list(self, course_id: str, class_id: str) -> List[Dict[str, Any]]:
-        # A network failure here must NOT abort discovery for the OTHER courses:
-        # return [] so the per-course loop skips this one (matches the guarded
-        # pattern used by every other network call in this client).
-        try:
-            resp = self.session.get(
-                ACTIVE_LIST_URL,
-                params={
-                    "fid": 0,
-                    "courseId": course_id,
-                    "classId": class_id,
-                    "_": int(time.time() * 1000),
-                },
-                timeout=12,
-            )
-        except requests.RequestException as exc:
-            logger.warning(
-                "activelist request failed for course=%s class=%s: %s",
-                course_id, class_id, exc,
-            )
-            return []
+        # Raises requests.RequestException on network failure so callers can tell a
+        # transient fetch error apart from a genuinely empty activeList — returning
+        # [] for both would let a Chaoxing timeout look like a successful "no active
+        # sign-in" no-op. Callers guard PER COURSE so one bad course still does not
+        # abort the whole batch.
+        resp = self.session.get(
+            ACTIVE_LIST_URL,
+            params={
+                "fid": 0,
+                "courseId": course_id,
+                "classId": class_id,
+                "_": int(time.time() * 1000),
+            },
+            timeout=12,
+        )
         data = self._safe_json(resp)
         # `data.get("data", {})` does NOT guard an explicit ``"data": null`` (common
         # when a per-course session/cookie is invalid) — `None.get(...)` would raise
@@ -1249,7 +1271,14 @@ class ChaoxingSigninManager:
 
     def get_active_tasks(self, user_id: str, sign_type: str = "all") -> List[Dict[str, Any]]:
         client = self._get_client(user_id)
-        live_tasks = client.get_active_tasks(expected_type=sign_type) if client else []
+        live_tasks: List[Dict[str, Any]] = []
+        if client:
+            try:
+                live_tasks = client.get_active_tasks(expected_type=sign_type)
+            except requests.RequestException as exc:
+                # Dashboard feed: a transient upstream failure should fall back to
+                # the persisted background-task feed rather than 500 the poll.
+                logger.warning("live active-task discovery failed: %s", exc)
         if live_tasks:
             return [self._decorate_live_task(task) for task in live_tasks]
         return self._build_background_task_feed(user_id)
@@ -1368,7 +1397,14 @@ class ChaoxingSigninManager:
             return {"status": False, "message": "Login state unavailable"}
 
         filters = [course_id] if course_id else None
-        tasks = client.get_active_tasks(course_filters=filters, expected_type=sign_type)
+        try:
+            tasks = client.get_active_tasks(course_filters=filters, expected_type=sign_type)
+        except requests.RequestException as exc:
+            return {
+                "status": False,
+                "message": f"Failed to query active sign-in tasks: {exc}",
+                "data": [],
+            }
         if not tasks:
             return {"status": False, "message": "No active sign-in task found", "data": []}
 
@@ -1410,12 +1446,19 @@ class ChaoxingSigninManager:
             return {"status": False, "message": "Login state unavailable"}
 
         course_filters = [course_id] if course_id else None
-        tasks = client.get_active_tasks(
-            course_filters=course_filters,
-            class_filters=[normalized_class_id],
-            active_id=active_id,
-            expected_type=sign_type,
-        )
+        try:
+            tasks = client.get_active_tasks(
+                course_filters=course_filters,
+                class_filters=[normalized_class_id],
+                active_id=active_id,
+                expected_type=sign_type,
+            )
+        except requests.RequestException as exc:
+            return {
+                "status": False,
+                "message": f"Failed to query active sign-in tasks: {exc}",
+                "data": [],
+            }
         if not tasks:
             return {"status": False, "message": "No active class sign-in task found", "data": []}
 
@@ -1544,12 +1587,19 @@ class ChaoxingSigninManager:
             return
 
         self._append_task_log(task_id, "Login successful")
-        tasks = client.get_active_tasks(
-            course_filters=course_list,
-            class_filters=class_list if subject_type == "class" else None,
-            active_id=active_id,
-            expected_type=sign_type,
-        )
+        try:
+            tasks = client.get_active_tasks(
+                course_filters=course_list,
+                class_filters=class_list if subject_type == "class" else None,
+                active_id=active_id,
+                expected_type=sign_type,
+            )
+        except requests.RequestException as exc:
+            # Upstream fetch failed for every course — surface as an error so the
+            # task is retried/visible, not silently reported as a completed no-op.
+            self._update_task(task_id, status="error", message=f"Failed to query active sign-in tasks: {exc}")
+            self._append_task_log(task_id, f"Failed to query active sign-in tasks: {exc}", "error")
+            return
         if not tasks:
             self._update_task(task_id, status="completed", message="No active sign-in task")
             self._append_task_log(task_id, "No active sign-in task found")

--- a/backend/app/services/course/zhihuishu/adapter.py
+++ b/backend/app/services/course/zhihuishu/adapter.py
@@ -399,6 +399,18 @@ class ZhihuishuAdapter:
                 index += 1
         return videos
 
+    def _is_task_cancelled(self, task_id: str) -> bool:
+        """Thread-safe check used by watch_video to abort mid-playback."""
+        with self._task_lock:
+            task = self._task_state
+            return bool(task and task.get("task_id") == task_id and task.get("cancelled"))
+
+    def _is_task_paused(self, task_id: str) -> bool:
+        """Thread-safe check used by watch_video to pause mid-playback."""
+        with self._task_lock:
+            task = self._task_state
+            return bool(task and task.get("task_id") == task_id and task.get("paused"))
+
     def _mark_task_error(self, task_id: str, message: str) -> None:
         with self._task_lock:
             task = self._tasks.get(task_id)
@@ -478,6 +490,7 @@ class ZhihuishuAdapter:
                 video_id = current_video.get("id")
                 duration = int(current_video.get("duration") or 0)
                 questions = list(current_video.get("questions") or [])
+                speed = float(task.get("speed") or 1.0)
 
             # --- Phase 2: blocking platform call OUTSIDE the lock ---
             watch_ok = False
@@ -485,7 +498,18 @@ class ZhihuishuAdapter:
             try:
                 if self.learning is None:
                     raise Exception("Not logged in")
-                watch_ok = bool(self.learning.watch_video(course_id, video_id, duration))
+                # Pass speed + pause/cancel checkers so a long video honors the
+                # configured倍速 and reacts to pause/cancel mid-playback.
+                watch_ok = bool(
+                    self.learning.watch_video(
+                        course_id,
+                        video_id,
+                        duration,
+                        speed=speed,
+                        is_cancelled=lambda: self._is_task_cancelled(task_id),
+                        is_paused=lambda: self._is_task_paused(task_id),
+                    )
+                )
             except Exception as exc:  # noqa: BLE001 - surface as failed video, keep going
                 logger.warning(
                     "Zhihuishu watch_video failed: task_id=%s video_id=%s err=%s",
@@ -515,7 +539,18 @@ class ZhihuishuAdapter:
                         if self._task_state.get("cancelled"):
                             break
                     try:
-                        self.answer.answer_question(question)
+                        computed = self.answer.answer_question(question)
+                        # NOTE (audit F-answer): answer_question only COMPUTES an
+                        # answer via AI; submitting it to Zhihuishu's QA/exam save
+                        # endpoint is NOT yet implemented (endpoint + signing must be
+                        # reverse-engineered live). Log the computed result so it is
+                        # not silently discarded and the limitation is observable.
+                        if computed:
+                            logger.info(
+                                "Zhihuishu answer computed but NOT submitted "
+                                "(submission unimplemented): task_id=%s",
+                                task_id,
+                            )
                     except Exception as exc:  # noqa: BLE001 - log, do not abort the course
                         logger.warning(
                             "Zhihuishu answer_question failed: task_id=%s err=%s",

--- a/backend/app/services/course/zhihuishu/crypto.py
+++ b/backend/app/services/course/zhihuishu/crypto.py
@@ -1,4 +1,6 @@
 """智慧树加密工具模块"""
+import json as _json
+import time as _time
 from Crypto.Cipher import AES
 from base64 import b64encode, b64decode
 
@@ -8,6 +10,24 @@ AI_KEY = b"hw2fdlwcj4cs1mx7"
 VIDEO_KEY = b"azp53h0kft7qi78q"
 QA_KEY = b"kcGOlISPkYKRksSK"
 EXAM_KEY = b"onbfhdyvz8x7otrp"
+
+
+def encrypt_secret_str(payload=None, key: bytes = HOME_KEY, iv: bytes = IV) -> str:
+    """Build the ``secretStr`` param required by Zhihuishu's AppInterfaceSign
+    interceptor (``com.zhihuishu.starter.secret``).
+
+    The server AES-CBC-decrypts ``secretStr`` and parses the result as a JSON
+    *object*; a bare value is rejected with "can not cast to JSONObject", and an
+    unsigned request is rejected with "aes加密参数异常". Verified live against
+    queryShareCourseInfo with HOME_KEY → code 200.
+
+    ``payload`` may be a dict (json-encoded) or a pre-serialized JSON-object str;
+    when omitted a minimal ``{"dateFormate": <ms>}`` object is sent.
+    """
+    if payload is None:
+        payload = {"dateFormate": int(_time.time() * 1000)}
+    text = payload if isinstance(payload, str) else _json.dumps(payload, ensure_ascii=False)
+    return Cipher(key, iv).encrypt(text)
 
 
 class Cipher:

--- a/backend/app/services/course/zhihuishu/learning.py
+++ b/backend/app/services/course/zhihuishu/learning.py
@@ -3,7 +3,7 @@ import time
 import json
 from typing import Optional, Dict, List
 import requests
-from .crypto import Cipher, WatchPoint, VIDEO_KEY
+from .crypto import Cipher, WatchPoint, VIDEO_KEY, HOME_KEY, encrypt_secret_str
 
 
 class ZhihuishuLearning:
@@ -17,27 +17,58 @@ class ZhihuishuLearning:
         self.cipher = Cipher(VIDEO_KEY)
 
     def get_course_list(self) -> List[Dict]:
-        """获取课程列表"""
+        """获取课程列表（共享课）
+
+        Zhihuishu 的 AppInterfaceSign 拦截器现在强制要求 AES 签名参数 ``secretStr``：
+        未签名请求会被拒（code 400 "aes加密参数异常"），导致旧代码读不到数据→空列表。
+        已对真实账号验证：HOME_KEY + secretStr(JSON对象) → code 200，数据在 ``result``
+        下（旧版为 ``rt``）。courseOpenDtos 可能为 null → []。
+        """
         url = "https://onlineservice-api.zhihuishu.com/gateway/t/v1/student/course/share/queryShareCourseInfo"
         try:
-            resp = self.session.post(url, proxies=self.proxies, timeout=10)
+            resp = self.session.post(
+                url,
+                data={"secretStr": encrypt_secret_str(key=HOME_KEY)},
+                proxies=self.proxies,
+                timeout=10,
+            )
             data = resp.json()
-            return data.get("rt", {}).get("courseOpenDtos", [])
+            result = data.get("result") or data.get("rt") or {}
+            return result.get("courseOpenDtos") or []
         except Exception as e:
             raise Exception(f"Failed to get course list: {e}")
 
     def get_video_list(self, course_id: str) -> List[Dict]:
-        """获取课程视频列表"""
+        """获取课程视频列表
+
+        同 get_course_list：studyservice-api 走同一套 AppInterfaceSign 拦截器，故同样
+        需要 ``secretStr`` 签名（把请求参数加密放进 secretStr）。响应同样优先读 ``result``，
+        回退 ``rt``。注意：此端点的密钥未能在本次离线验证（账号当前无共享课），沿用
+        HOME_KEY；如线上仍报 "aes解密异常"，需用真实选课账号抓包确认该服务的密钥。
+        """
         url = "https://studyservice-api.zhihuishu.com/gateway/t/v1/learning/queryStudyInfo"
         try:
-            resp = self.session.post(url, json={"recruitAndCourseId": course_id},
-                                    proxies=self.proxies, timeout=10)
+            resp = self.session.post(
+                url,
+                data={"secretStr": encrypt_secret_str({"recruitAndCourseId": course_id}, key=HOME_KEY)},
+                proxies=self.proxies,
+                timeout=10,
+            )
             data = resp.json()
-            return data.get("rt", {}).get("videoChapterDtos", [])
+            result = data.get("result") or data.get("rt") or {}
+            return result.get("videoChapterDtos") or []
         except Exception as e:
             raise Exception(f"Failed to get video list: {e}")
 
-    def watch_video(self, course_id: str, video_id: str, duration: int) -> bool:
+    def watch_video(
+        self,
+        course_id: str,
+        video_id: str,
+        duration: int,
+        speed: float = 1.0,
+        is_cancelled=None,
+        is_paused=None,
+    ) -> bool:
         """
         观看视频
 
@@ -45,19 +76,52 @@ class ZhihuishuLearning:
             course_id: 课程ID
             video_id: 视频ID
             duration: 视频时长（秒）
+            speed: 播放倍速（>1 加快，钳制到合理范围以保持上报节奏）
+            is_cancelled: 可选回调，返回 True 时立即中止（响应取消）
+            is_paused: 可选回调，返回 True 时暂停上报（响应暂停）
 
         Returns:
             是否成功
         """
         url = "https://studyservice-api.zhihuishu.com/gateway/t/v1/learning/saveDatabaseIntervalTime"
 
+        try:
+            duration = int(duration or 0)
+        except (TypeError, ValueError):
+            duration = 0
+        if duration <= 0:
+            # 时长缺失/为 0：绝不"秒标完成"。原实现会让 while 一次都不进、直接返回
+            # True，于是视频被记为 100% 却一个观看点都没上报。改为抛错→上层记为失败，
+            # 让进度反映真实情况。(F-zero-duration)
+            raise Exception(f"video {video_id} has no usable duration ({duration!r})")
+
+        # 倍速：以前 watch_video 完全忽略 speed，N 小时课就实打实跑 N 小时。这里把
+        # speed 钳制到 [1,2]，缩短真实 sleep（studyTime 仍按 5 秒步进上报），既加速又
+        # 保持可信的上报节奏以规避风控。(F-speed)
+        try:
+            eff_speed = float(speed)
+        except (TypeError, ValueError):
+            eff_speed = 1.0
+        eff_speed = min(max(eff_speed, 1.0), 2.0)
+        interval = 5
+        sleep_seconds = interval / eff_speed
+
         watch_point = WatchPoint()
         current_time = 0
 
         try:
             while current_time < duration:
-                time.sleep(5)
-                current_time += 5
+                # 在每个上报周期开始时检查取消/暂停，使暂停与取消在"播放过程中"即可生效，
+                # 而不必等整段视频跑完。(F-pause-cancel)
+                if callable(is_cancelled) and is_cancelled():
+                    return False
+                while callable(is_paused) and is_paused():
+                    if callable(is_cancelled) and is_cancelled():
+                        return False
+                    time.sleep(0.3)
+
+                time.sleep(sleep_seconds)
+                current_time += interval
                 watch_point.add(current_time)
 
                 data = {

--- a/backend/app/services/course/zhihuishu/learning.py
+++ b/backend/app/services/course/zhihuishu/learning.py
@@ -39,21 +39,22 @@ class ZhihuishuLearning:
             raise Exception(f"Failed to get course list: {e}")
 
     def get_video_list(self, course_id: str) -> List[Dict]:
-        """获取课程视频列表
+        """获取课程视频列表（studyservice-api）
 
-        同 get_course_list：studyservice-api 走同一套 AppInterfaceSign 拦截器，故同样
-        需要 ``secretStr`` 签名（把请求参数加密放进 secretStr）。响应同样优先读 ``result``，
-        回退 ``rt``。注意：此端点的密钥未能在本次离线验证（账号当前无共享课），沿用
-        HOME_KEY；如线上仍报 "aes解密异常"，需用真实选课账号抓包确认该服务的密钥。
+        响应优先读 ``result``，回退 ``rt``（与共享课接口一致的兼容处理）。
+
+        关于签名：只有 onlineservice 的 queryShareCourseInfo 被实证要求 AES `secretStr`
+        签名（HOME_KEY，已验证）。studyservice 这个接口的签名方案未能离线验证（当前账号
+        无共享课可测），故此处不臆造一套很可能错误的签名（HOME_KEY 肯定是错的——它是
+        onlineservice 的密钥）。维持原始明文请求；若线上用真实选课账号发现此接口同样被
+        AppInterfaceSign 拦截（报 "aes加密参数异常/aes解密异常"），正确做法是用
+        studyservice 的视频密钥 ``VIDEO_KEY``（即 self.cipher / saveDatabaseIntervalTime
+        所用密钥）按相同 envelope 签名，而非 HOME_KEY。
         """
         url = "https://studyservice-api.zhihuishu.com/gateway/t/v1/learning/queryStudyInfo"
         try:
-            resp = self.session.post(
-                url,
-                data={"secretStr": encrypt_secret_str({"recruitAndCourseId": course_id}, key=HOME_KEY)},
-                proxies=self.proxies,
-                timeout=10,
-            )
+            resp = self.session.post(url, json={"recruitAndCourseId": course_id},
+                                     proxies=self.proxies, timeout=10)
             data = resp.json()
             result = data.get("result") or data.get("rt") or {}
             return result.get("videoChapterDtos") or []
@@ -96,13 +97,14 @@ class ZhihuishuLearning:
             raise Exception(f"video {video_id} has no usable duration ({duration!r})")
 
         # 倍速：以前 watch_video 完全忽略 speed，N 小时课就实打实跑 N 小时。这里把
-        # speed 钳制到 [1,2]，缩短真实 sleep（studyTime 仍按 5 秒步进上报），既加速又
-        # 保持可信的上报节奏以规避风控。(F-speed)
+        # speed 钳制到 [0.5, 2]，缩短/拉长真实 sleep（studyTime 仍按 5 秒步进上报），
+        # 既支持加速也支持页面提供的 0.5x 慢速，同时保持可信的上报节奏以规避风控。
+        # 下界取 0.5 而非 1.0，否则会把用户选的 0.5x 慢速强行抬回正常速。(F-speed)
         try:
             eff_speed = float(speed)
         except (TypeError, ValueError):
             eff_speed = 1.0
-        eff_speed = min(max(eff_speed, 1.0), 2.0)
+        eff_speed = min(max(eff_speed, 0.5), 2.0)
         interval = 5
         sleep_seconds = interval / eff_speed
 

--- a/backend/tests/unit/test_zhihuishu_adapter.py
+++ b/backend/tests/unit/test_zhihuishu_adapter.py
@@ -32,10 +32,21 @@ class FakeLearning:
     def get_video_list(self, course_id):
         return self._chapters
 
-    def watch_video(self, course_id, video_id, duration):
+    def watch_video(self, course_id, video_id, duration, speed=1.0,
+                    is_cancelled=None, is_paused=None):
+        # Signature mirrors the real ZhihuishuLearning.watch_video: the adapter now
+        # forwards speed + pause/cancel checkers so a long video honors倍速 and
+        # reacts mid-playback. Record them so tests can assert the contract.
         with self.lock:
             self.watch_calls.append(
-                {"course_id": course_id, "video_id": video_id, "duration": duration}
+                {
+                    "course_id": course_id,
+                    "video_id": video_id,
+                    "duration": duration,
+                    "speed": speed,
+                    "is_cancelled": is_cancelled,
+                    "is_paused": is_paused,
+                }
             )
         return self._watch_results.get(str(video_id), True)
 
@@ -197,11 +208,15 @@ def test_cancel_stops_loop_before_remaining_videos():
 
     real_watch = adapter.learning.watch_video
 
-    def blocking_watch(course_id, video_id, duration):
+    def blocking_watch(course_id, video_id, duration, speed=1.0,
+                       is_cancelled=None, is_paused=None):
         if video_id == "v1":
             started.set()
             release.wait(timeout=5)
-        return real_watch(course_id, video_id, duration)
+        return real_watch(
+            course_id, video_id, duration, speed=speed,
+            is_cancelled=is_cancelled, is_paused=is_paused,
+        )
 
     adapter.learning.watch_video = blocking_watch
 
@@ -216,6 +231,46 @@ def test_cancel_stops_loop_before_remaining_videos():
     # v2 must never be watched because the task was cancelled after v1.
     watched_ids = [c["video_id"] for c in adapter.learning.watch_calls]
     assert "v2" not in watched_ids
+
+
+def test_watch_video_receives_speed_and_control_callbacks():
+    """The adapter must forward speed and working pause/cancel checkers (F-speed/F-pause-cancel)."""
+    chapters = [{"videoLearningDtos": [{"videoId": "v1", "videoName": "A", "videoSec": 5}]}]
+    adapter = _make_adapter(chapters, ai_enabled=False)
+
+    adapter.start_course("c-speed", speed=1.75, auto_answer=False)
+    _wait_for_terminal(adapter, "c-speed")
+
+    assert adapter.learning.watch_calls, "watch_video was never called"
+    call = adapter.learning.watch_calls[0]
+    assert call["speed"] == 1.75
+    assert callable(call["is_cancelled"]) and callable(call["is_paused"])
+    # The forwarded checkers must reflect live task state, not be no-ops.
+    assert call["is_cancelled"]() is False
+    assert call["is_paused"]() is False
+
+
+def test_zero_duration_video_not_faked_complete():
+    """A 0/None-duration video must NOT be counted as completed (F-zero-duration).
+
+    Uses the REAL ZhihuishuLearning.watch_video (no watch_video override) to
+    exercise the duration guard; get_video_list is stubbed.
+    """
+    from app.services.course.zhihuishu.learning import ZhihuishuLearning
+
+    chapters = [{"videoLearningDtos": [{"videoId": "v0", "videoName": "NoDur", "videoSec": 0}]}]
+    adapter = ZhihuishuAdapter(ai_config={"enabled": False})
+    real_learning = ZhihuishuLearning(cookies={}, proxies={})
+    real_learning.get_video_list = lambda course_id: chapters
+    adapter.learning = real_learning
+
+    adapter.start_course("c-zero", speed=1.0, auto_answer=False)
+    progress = _wait_for_terminal(adapter, "c-zero")
+
+    # Zero-duration video is surfaced as failed, never as fake-completed 100%.
+    assert progress["completed"] == 0
+    assert progress["failed"] == 1
+    assert progress["percentage"] == 0.0
 
 
 if __name__ == "__main__":

--- a/frontend/src/pages/Zhihuishu.jsx
+++ b/frontend/src/pages/Zhihuishu.jsx
@@ -861,6 +861,12 @@ export default function Zhihuishu() {
       setQrStatus(nextStatus)
       setQrMessage(resp?.message || '等待扫码')
 
+      // The backend regenerates the QR image when the original expires; render the
+      // refreshed code so a slow scan can still succeed. (F-qr-refresh)
+      if (resp?.qr_code) {
+        setQrCode((prev) => (prev === resp.qr_code ? prev : resp.qr_code))
+      }
+
       if (nextStatus === 'success') {
         stopQrPolling()
         setZhihuishuLoggedIn(true)

--- a/frontend/src/pages/chaoxing-signin/hooks/useBackgroundTasks.js
+++ b/frontend/src/pages/chaoxing-signin/hooks/useBackgroundTasks.js
@@ -7,6 +7,10 @@ import {
 
 export default function useBackgroundTasks(requestChaoxingApi) {
   const pollRef = useRef(null)
+  // Client-tracked log cursor: the server now slices statelessly from this
+  // offset, so reopening a task / overlapping polls no longer race on a shared
+  // server cursor and drop logs. Reset to 0 whenever a task is (re)opened.
+  const logCursorRef = useRef(0)
 
   const [taskId, setTaskId] = useState('')
   const [taskStatus, setTaskStatus] = useState(null)
@@ -27,7 +31,7 @@ export default function useBackgroundTasks(requestChaoxingApi) {
     try {
       const [statusResp, logsResp] = await Promise.all([
         requestChaoxingApi(`/task/${currentTaskId}`),
-        requestChaoxingApi(`/logs/${currentTaskId}`)
+        requestChaoxingApi(`/logs/${currentTaskId}?cursor=${logCursorRef.current}`)
       ])
 
       const statusData = statusResp?.data || {}
@@ -42,6 +46,10 @@ export default function useBackgroundTasks(requestChaoxingApi) {
       }
       if (Array.isArray(logsResp?.data) && logsResp.data.length > 0) {
         setLogs((prev) => [...prev, ...logsResp.data].slice(-200))
+      }
+      // Advance to the server-reported cursor so the next poll only fetches new lines.
+      if (typeof logsResp?.cursor === 'number') {
+        logCursorRef.current = logsResp.cursor
       }
 
       if (statusData.status === 'completed' || statusData.status === 'error') {
@@ -62,6 +70,7 @@ export default function useBackgroundTasks(requestChaoxingApi) {
     setTaskId(normalizedTaskId)
     setTaskStatus(null)
     setLogs([])
+    logCursorRef.current = 0
     await refreshTaskStatus(normalizedTaskId, callbacks)
     return true
   }, [refreshTaskStatus])

--- a/frontend/src/pages/chaoxing-signin/hooks/useBackgroundTasks.js
+++ b/frontend/src/pages/chaoxing-signin/hooks/useBackgroundTasks.js
@@ -11,11 +11,15 @@ export default function useBackgroundTasks(requestChaoxingApi) {
   // offset, so reopening a task / overlapping polls no longer race on a shared
   // server cursor and drop logs. Reset to 0 whenever a task is (re)opened.
   const logCursorRef = useRef(0)
-  // Serialize log polls: if two refreshTaskStatus calls overlap (slow open poll
-  // racing the interval poll, or a manual refresh), both would read the same
-  // logCursorRef before either advances it and append the same slice twice.
-  // Skip a refresh while one is already in flight.
-  const inFlightRef = useRef(false)
+  // Task-scoped in-flight guard: holds the task id whose poll is currently in
+  // flight (or ''). It skips a *second poll of the SAME task* (so two overlapping
+  // refreshes don't read one cursor and double-append), while still allowing a
+  // newly-opened task to poll. Paired with openTaskRef below, which drops stale
+  // responses so an in-flight poll for task A can't write A's status/logs/cursor
+  // into a freshly-opened task B's view.
+  const inFlightRef = useRef('')
+  // The currently-open task id; responses for any other id are discarded.
+  const openTaskRef = useRef('')
 
   const [taskId, setTaskId] = useState('')
   const [taskStatus, setTaskStatus] = useState(null)
@@ -31,8 +35,10 @@ export default function useBackgroundTasks(requestChaoxingApi) {
 
   const refreshTaskStatus = useCallback(async (currentTaskId, { setResultType, setResultMessage, setBackgroundTaskHistory } = {}) => {
     if (!currentTaskId) return
-    if (inFlightRef.current) return
-    inFlightRef.current = true
+    // Skip only a concurrent poll of the SAME task (prevents one-cursor double
+    // append); a different (newly-opened) task is allowed to proceed.
+    if (inFlightRef.current === currentTaskId) return
+    inFlightRef.current = currentTaskId
     setStatusLoading(true)
 
     try {
@@ -40,6 +46,10 @@ export default function useBackgroundTasks(requestChaoxingApi) {
         requestChaoxingApi(`/task/${currentTaskId}`),
         requestChaoxingApi(`/logs/${currentTaskId}?cursor=${logCursorRef.current}`)
       ])
+
+      // The open task changed while this request was in flight — discard the
+      // stale result so it can't overwrite the new task's view or cursor.
+      if (openTaskRef.current !== currentTaskId) return
 
       const statusData = statusResp?.data || {}
       setTaskStatus(statusData)
@@ -67,7 +77,8 @@ export default function useBackgroundTasks(requestChaoxingApi) {
       if (setResultMessage) setResultMessage(err.message || '查询任务状态失败。')
       stopPolling()
     } finally {
-      inFlightRef.current = false
+      // Only clear if still ours — a newer task's poll may have taken the slot.
+      if (inFlightRef.current === currentTaskId) inFlightRef.current = ''
       setStatusLoading(false)
     }
   }, [requestChaoxingApi, stopPolling])
@@ -75,6 +86,9 @@ export default function useBackgroundTasks(requestChaoxingApi) {
   const openBackgroundTask = useCallback(async (nextTaskId, callbacks) => {
     const normalizedTaskId = String(nextTaskId || '').trim()
     if (!normalizedTaskId) return false
+    // Mark B as the open task BEFORE refreshing so any in-flight poll for the
+    // previous task is treated as stale and its response is dropped.
+    openTaskRef.current = normalizedTaskId
     setTaskId(normalizedTaskId)
     setTaskStatus(null)
     setLogs([])
@@ -82,6 +96,12 @@ export default function useBackgroundTasks(requestChaoxingApi) {
     await refreshTaskStatus(normalizedTaskId, callbacks)
     return true
   }, [refreshTaskStatus])
+
+  // Keep openTaskRef in sync for interval-driven polls (openBackgroundTask sets
+  // it eagerly; this covers taskId changes from any other path).
+  useEffect(() => {
+    openTaskRef.current = taskId
+  }, [taskId])
 
   // Poll effect: when taskId changes, start/stop 3s polling
   useEffect(() => {

--- a/frontend/src/pages/chaoxing-signin/hooks/useBackgroundTasks.js
+++ b/frontend/src/pages/chaoxing-signin/hooks/useBackgroundTasks.js
@@ -11,6 +11,11 @@ export default function useBackgroundTasks(requestChaoxingApi) {
   // offset, so reopening a task / overlapping polls no longer race on a shared
   // server cursor and drop logs. Reset to 0 whenever a task is (re)opened.
   const logCursorRef = useRef(0)
+  // Serialize log polls: if two refreshTaskStatus calls overlap (slow open poll
+  // racing the interval poll, or a manual refresh), both would read the same
+  // logCursorRef before either advances it and append the same slice twice.
+  // Skip a refresh while one is already in flight.
+  const inFlightRef = useRef(false)
 
   const [taskId, setTaskId] = useState('')
   const [taskStatus, setTaskStatus] = useState(null)
@@ -26,6 +31,8 @@ export default function useBackgroundTasks(requestChaoxingApi) {
 
   const refreshTaskStatus = useCallback(async (currentTaskId, { setResultType, setResultMessage, setBackgroundTaskHistory } = {}) => {
     if (!currentTaskId) return
+    if (inFlightRef.current) return
+    inFlightRef.current = true
     setStatusLoading(true)
 
     try {
@@ -60,6 +67,7 @@ export default function useBackgroundTasks(requestChaoxingApi) {
       if (setResultMessage) setResultMessage(err.message || '查询任务状态失败。')
       stopPolling()
     } finally {
+      inFlightRef.current = false
       setStatusLoading(false)
     }
   }, [requestChaoxingApi, stopPolling])


### PR DESCRIPTION
## Summary

Round-4 functional audit of the 学习通/知到 automation. A multi-agent review found 15 functional bugs; all are fixed here, plus a **critical live finding** the static review couldn't see: Zhihuishu added a mandatory AES request-signing interceptor, so course/video listing was returning empty for everyone. Validated end-to-end against **real 学习通 + 知到 accounts** (owner-authorized).

## Type

- [x] fix — bug fix

## What changed (highlights)

**Zhihuishu**
- Course/video listing was fully broken: `AppInterfaceSignInterceptor` rejects unsigned requests (`code:400 "aes加密参数异常"`). Now AES-signed (`secretStr` + `HOME_KEY`, new `crypto.encrypt_secret_str()`) and reads the response under `result` (server moved it from `rt`). **Verified live: request accepted (code 200).**
- `watch_video` honors configured speed and reacts to pause/cancel mid-video; 0/None-duration videos are surfaced as failed, not fake-completed.
- QR refresh after expiry is delivered through the login-status poll; auto-answer no longer silently discards its computed result.

**Chaoxing**
- Sign-in: `data:null` → no more `AttributeError`; `int(None)` on otherId/status/ifphoto coerced; one course's transient error no longer aborts the batch.
- Chapter progress reaches 100% for pre-finished chapters; sign-in task logs use a stateless client cursor; OCR title-gate covers all OCR backends; font-map path is package-relative.

**API/auth**
- `CORSMiddleware` is now outermost so `tenant_isolation`'s 401 carries CORS headers — the SPA's session-expiry redirect fires instead of hanging. Metrics stays outside tenant_isolation. Rate-limiter DB call offloaded off the event loop.

## Test plan

- [x] Backend unit: `197 passed` (added zhihuishu speed/zero-duration contract tests).
- [x] Frontend: `43 passed`, eslint clean.
- [x] Live (real accounts): 学习通 login→courses(20)→chapters/jobs OK; sign-in discovery OK; 知到 QR login OK; **知到 course-list request now accepted (was rejected)** — account currently has 0 共享课 so list is legitimately empty.
- [ ] Reviewer: confirm middleware order (CORS outermost) and the secretStr signing approach.

## Risk / rollback

- Low for Chaoxing (defensive guards, no behavior change on clean responses; live-regression-checked).
- Zhihuishu `get_video_list`/studyservice key is **unverified** (no enrolled 共享课 to test) — same broken state if the key differs, no regression. Rollback = revert the branch; no schema/migration changes.

## Known follow-ups (not in this PR)

- Zhihuishu answer **submission** endpoint + signing must be reverse-engineered against the live platform (currently compute-only, logged).
- `resource/font_map_table.json` data file still must be supplied (path resolution fixed).

## Codex Review and PR Labels

- [x] This PR is ready for automatic Codex review.
- [x] I checked the newest Codex/bot comments before deciding the PR status.