### PR TITLE
[codex] docs: add demo site link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@
 </p>
 
 <p align="center">
+  <strong>Demo:</strong>
+  <a href="https://shuake.cornna.xyz">shuake.cornna.xyz</a>
+</p>
+
+<p align="center">
   <img src="docs/university-helper-promo.gif" alt="University Helper — 60-second product film: while you sleep, it signs in, watches lectures and answers quizzes on Chaoxing and Zhihuishu, finishing by dawn" width="640" />
   <br />
   <sub><b>“You sleep, it studies.”</b> — 60-second product film, rendered frame-by-frame with Remotion</sub>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,6 +3,11 @@
 # University Helper
 
 <p align="center">
+  <strong>演示网站：</strong>
+  <a href="https://shuake.cornna.xyz">shuake.cornna.xyz</a>
+</p>
+
+<p align="center">
   <img src="docs/university-helper-promo.gif" alt="University Helper 产品宣传片：你睡觉时，它在超星学习通 / 智慧树替你签到、刷课、答题，天亮前全部完成" width="640" />
   <br />
   <sub><b>「你睡觉，它上课」</b> — 60 秒产品宣传片，使用 Remotion 逐帧渲染</sub>


### PR DESCRIPTION
## Summary

Adds the public demo site link `https://shuake.cornna.xyz` near the top of both README entry points:

- `README.md`
- `README.zh-CN.md`

## Why

This makes the hosted demo easy to find for English and Chinese readers as soon as they open the project page.

## Impact

Documentation-only change. No runtime behavior changes.

## Validation

- `git diff --cached --check`
- `git diff --check origin/main...HEAD`