### PR TITLE
fix(zhihuishu): load 知到/智慧树 courses + real progress reporting (v1.2.2)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -70,7 +70,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="University Helper API",
     description="Multi-tenant campus helper platform with database-per-tenant isolation",
-    version="1.2.1",
+    version="1.2.2",
     docs_url="/docs" if settings.DOCS_ENABLED else None,
     redoc_url="/redoc" if settings.DOCS_ENABLED else None,
     openapi_url="/openapi.json" if settings.DOCS_ENABLED else None,

--- a/backend/app/services/course/zhihuishu/adapter.py
+++ b/backend/app/services/course/zhihuishu/adapter.py
@@ -45,7 +45,8 @@ class ZhihuishuAdapter:
         return {"success": True, "cookies": cookies}
 
     def _init_services(self, cookies: dict):
-        self.learning = ZhihuishuLearning(cookies, self.proxies)
+        # uuid（从 CASLOGC cookie 解出）是进度上报 ev 的必需字段，透传给 learning。
+        self.learning = ZhihuishuLearning(cookies, self.proxies, uuid=self.auth.uuid)
         self.answer = ZhihuishuAnswer(cookies, self.ai_config, self.proxies)
 
     @staticmethod
@@ -96,6 +97,17 @@ class ZhihuishuAdapter:
                 return course
         raise Exception("Course not found")
 
+    def _resolve_rac_id(self, course_id: str) -> str:
+        """把前端选中的 courseId 映射为视频接口所需的 recruitAndCourseId（= 课程 secret）。
+
+        映射失败（取不到列表/课程不在列表里）时回退用 course_id 本身，保证不致命。
+        """
+        try:
+            course = self.get_course_detail(course_id)
+        except Exception:
+            return str(course_id)
+        return str(course.get("recruitAndCourseId") or course.get("secret") or course_id)
+
     def get_videos(self, course_id: str) -> list[dict]:
         if not self.learning:
             raise Exception("Not logged in")
@@ -104,8 +116,32 @@ class ZhihuishuAdapter:
             if self._task_state and self._task_state.get("course_id") == course_id:
                 return list(self._task_state.get("videos", []))
 
-        chapters = self.learning.get_video_list(course_id)
-        return self._flatten_videos(chapters)
+        rac_id = self._resolve_rac_id(course_id)
+        data = self.learning.get_video_list(rac_id)
+        videos = self._flatten_videos(data, rac_id)
+        self._annotate_watch_state(videos, data)
+        return videos
+
+    def _annotate_watch_state(self, videos: list[dict], data: Any) -> None:
+        """给每个视频补上 study_total_time / watch_state，供 watch_video 续播与跳过已完成。
+
+        失败（接口异常 / mock 无该方法）时静默忽略：watch_video 会按未学（从 0 开始）处理。
+        """
+        if not videos:
+            return
+        recruit_id = data.get("recruitId") if isinstance(data, dict) else None
+        lesson_ids = sorted({v["lesson_id"] for v in videos if v.get("lesson_id")}, key=str)
+        video_ids = sorted({v["small_lesson_id"] for v in videos if v.get("small_lesson_id")}, key=str)
+        try:
+            info = self.learning.query_study_info(lesson_ids, video_ids, recruit_id)
+        except Exception:  # noqa: BLE001 - 状态拉取失败不致命
+            return
+        lv = info.get("lv") or {}
+        lesson = info.get("lesson") or {}
+        for v in videos:
+            state = lv.get(str(v.get("small_lesson_id"))) or lesson.get(str(v.get("lesson_id"))) or {}
+            v["study_total_time"] = state.get("studyTotalTime") or 0
+            v["watch_state"] = state.get("watchState") or 0
 
     def start_course(self, course_id: str, speed: float = 1.0, auto_answer: bool = True) -> dict:
         if not self.learning:
@@ -368,24 +404,67 @@ class ZhihuishuAdapter:
         return []
 
     @staticmethod
-    def _flatten_videos(chapters: list[dict[str, Any]]) -> list[dict]:
+    def _flatten_videos(data: Any, rac_id: str | None = None) -> list[dict]:
+        """把 videolist 的 ``data`` 拍平成任务用的视频列表，并携带上报所需上下文。
+
+        真实结构是 ``videoChapterDtos[].videoLessons[].videoSmallLessons[]``；单视频小节
+        （lesson 自带 ``videoId``、无 ``videoSmallLessons``）按一个 small lesson（id=0）处理。
+        同时兼容旧/测试结构（章节直接挂 ``videoLearningDtos``/``videoDtos``）。
+        """
+        if isinstance(data, dict):
+            chapters = data.get("videoChapterDtos") or []
+            course_id = data.get("courseId")
+            recruit_id = data.get("recruitId")
+        else:
+            chapters = data or []
+            course_id = None
+            recruit_id = None
+
         videos: list[dict[str, Any]] = []
         index = 1
-        for chapter in chapters or []:
-            chapter_videos = chapter.get("videoLearningDtos") or chapter.get("videoDtos") or []
-            for item in chapter_videos:
-                title = item.get("videoName") or item.get("name") or item.get("lessonVideoName") or f"Video {index}"
-                videos.append(
-                    {
-                        "id": str(item.get("videoId") or item.get("id") or index),
-                        "title": title,
-                        "duration": item.get("videoSec") or item.get("duration") or 0,
-                        "status": "pending",
-                        "progress": 0,
-                        "questions": ZhihuishuAdapter._extract_questions(item),
-                    }
-                )
-                index += 1
+        for chapter in chapters:
+            chapter_id = chapter.get("id") or chapter.get("chapterId")
+            lessons = (
+                chapter.get("videoLessons") or chapter.get("videoLearningDtos") or chapter.get("videoDtos") or []
+            )
+            for lesson in lessons:
+                lesson_id = lesson.get("id") or lesson.get("lessonId")
+                smalls = lesson.get("videoSmallLessons") or [lesson]
+                for small in smalls:
+                    is_single = small is lesson
+                    video_id = small.get("videoId") or small.get("id")
+                    title = (
+                        small.get("name")
+                        or small.get("videoName")
+                        or lesson.get("name")
+                        or lesson.get("videoName")
+                        or lesson.get("lessonVideoName")
+                        or f"Video {index}"
+                    )
+                    video_sec = small.get("videoSec") or small.get("duration") or 0
+                    questions = ZhihuishuAdapter._extract_questions(small)
+                    if not questions and not is_single:
+                        questions = ZhihuishuAdapter._extract_questions(lesson)
+                    videos.append(
+                        {
+                            "id": str(video_id or index),
+                            "title": title,
+                            "duration": video_sec,
+                            "status": "pending",
+                            "progress": 0,
+                            "questions": questions,
+                            # --- 进度上报上下文 ---
+                            "recruit_and_course_id": rac_id,
+                            "recruit_id": recruit_id,
+                            "course_id": course_id,
+                            "chapter_id": chapter_id,
+                            "lesson_id": lesson_id,
+                            "small_lesson_id": 0 if is_single else small.get("id"),
+                            "video_id": video_id,
+                            "video_sec": video_sec,
+                        }
+                    )
+                    index += 1
         return videos
 
     def _is_task_cancelled(self, task_id: str) -> bool:
@@ -474,10 +553,8 @@ class ZhihuishuAdapter:
                 task["current_video"] = current_video.get("title")
                 task["status"] = "running"
                 task["message"] = "Task is running"
-                course_id = task.get("course_id")
                 auto_answer = bool(task.get("auto_answer", True))
                 video_id = current_video.get("id")
-                duration = int(current_video.get("duration") or 0)
                 questions = list(current_video.get("questions") or [])
                 speed = float(task.get("speed") or 1.0)
 
@@ -487,13 +564,12 @@ class ZhihuishuAdapter:
             try:
                 if self.learning is None:
                     raise Exception("Not logged in")
-                # Pass speed + pause/cancel checkers so a long video honors the
-                # configured倍速 and reacts to pause/cancel mid-playback.
+                # Pass the full video context dict (recruit/chapter/lesson/video ids +
+                # videoSec) so watch_video can sign the real saveDatabaseIntervalTimeV2
+                # report, plus speed + pause/cancel checkers for倍速 and mid-playback control.
                 watch_ok = bool(
                     self.learning.watch_video(
-                        course_id,
-                        video_id,
-                        duration,
+                        current_video,
                         speed=speed,
                         is_cancelled=lambda: self._is_task_cancelled(task_id),
                         is_paused=lambda: self._is_task_paused(task_id),

--- a/backend/app/services/course/zhihuishu/crypto.py
+++ b/backend/app/services/course/zhihuishu/crypto.py
@@ -1,5 +1,6 @@
 """智慧树加密工具模块"""
 
+import datetime as _datetime
 import json as _json
 import time as _time
 from base64 import b64decode, b64encode
@@ -30,6 +31,39 @@ def encrypt_secret_str(payload=None, key: bytes = HOME_KEY, iv: bytes = IV) -> s
         payload = {"dateFormate": int(_time.time() * 1000)}
     text = payload if isinstance(payload, str) else _json.dumps(payload, ensure_ascii=False)
     return Cipher(key, iv).encrypt(text)
+
+
+def get_ev(data: list, key: str = "zzpttjd") -> str:
+    """Build the ``ev`` / ``sdsew`` obfuscation param used by Zhihuishu's video
+    progress-report endpoints (saveDatabaseIntervalTime / ...V2).
+
+    The fields in ``data`` are ``';'``-joined, then each character is XOR-ed
+    against a cyclically-repeating ``key`` and emitted as 2-hex-digit pairs.
+    ``saveDatabaseIntervalTime`` uses the default key ``zzpttjd`` (the meet-course
+    endpoint uses ``zhihuishu``). Ported verbatim from the upstream reference so
+    the produced ``ev`` is byte-compatible with the live API.
+    """
+
+    def _key_stream():
+        while True:
+            for ch in key:
+                yield ord(ch)
+
+    stream = _key_stream()
+    joined = ";".join(map(str, data))
+    ev = ""
+    for ch in joined:
+        tmp = hex(ord(ch) ^ next(stream)).replace("0x", "")
+        if len(tmp) < 2:
+            tmp = "0" + tmp
+        # upstream slices [-4:]; for a single byte this equals the 2-hex pair.
+        ev += tmp[-4:]
+    return ev
+
+
+def hms(seconds: int) -> str:
+    """Format a second count as ``H:MM:SS`` for the ``ev`` time field."""
+    return str(_datetime.timedelta(seconds=int(seconds)))
 
 
 class Cipher:

--- a/backend/app/services/course/zhihuishu/learning.py
+++ b/backend/app/services/course/zhihuishu/learning.py
@@ -1,121 +1,252 @@
 """智慧树自动学习模块"""
 
-import json
+import logging
+import math
 import time
+from base64 import b64encode
 
 import requests
 
-from .crypto import HOME_KEY, VIDEO_KEY, Cipher, WatchPoint, encrypt_secret_str
+from .crypto import HOME_KEY, VIDEO_KEY, WatchPoint, encrypt_secret_str, get_ev, hms
+
+logger = logging.getLogger(__name__)
+
+# 站点（用于 Origin/Referer，部分网关接口缺失会被风控拦）
+ONLINEWEB = "https://onlineweb.zhihuishu.com"
+STUDYH5 = "https://studyh5.zhihuishu.com"
+
+# 接口地址
+COURSE_LIST_URL = "https://onlineservice-api.zhihuishu.com/gateway/t/v1/student/course/share/queryShareCourseInfo"
+GOLOGIN_URL = "https://studyservice-api.zhihuishu.com/login/gologin"
+QUERY_COURSE_URL = "https://studyservice-api.zhihuishu.com/gateway/t/v1/learning/queryCourse"
+VIDEO_LIST_URL = "https://studyservice-api.zhihuishu.com/gateway/t/v1/learning/videolist"
+PRELEARNING_NOTE_URL = "https://studyservice-api.zhihuishu.com/gateway/t/v1/learning/prelearningNote"
+SAVE_DB_V2_URL = "https://studyservice-api.zhihuishu.com/gateway/t/v1/learning/saveDatabaseIntervalTimeV2"
+# 注意："Stuy" 是平台接口本身的拼写错误，不是笔误
+QUERY_STUDY_INFO_URL = "https://studyservice-api.zhihuishu.com/gateway/t/v1/learning/queryStuyInfo"
+
+PAGE_SIZE = 5
+DB_REPORT_INTERVAL = 30  # 真实秒：每 30 秒上报一次进度（与官方客户端节奏一致）
+# 共享课状态：0=进行中, 1=已完成。两者都拉，否则已完成的课会"加载不出来"。
+COURSE_STATUSES = (0, 1)
+
+
+def _extract(payload: dict) -> dict:
+    """读取智慧树网关响应里的数据体。
+
+    共享课接口的数据在 ``result``，studyservice 接口在 ``data``，旧版网关为 ``rt``。
+    """
+    if not isinstance(payload, dict):
+        return {}
+    for key in ("data", "result", "rt"):
+        value = payload.get(key)
+        if isinstance(value, dict):
+            return value
+    return {}
 
 
 class ZhihuishuLearning:
     """智慧树自动学习服务"""
 
-    def __init__(self, cookies: dict, proxies: dict | None = None):
+    def __init__(self, cookies: dict, proxies: dict | None = None, uuid: str | None = None):
         self.cookies = cookies
         self.proxies = proxies or {}
+        self.uuid = uuid or ""
         self.session = requests.Session()
         self.session.cookies.update(cookies)
-        self.cipher = Cipher(VIDEO_KEY)
+
+    def _signed_post(self, url: str, payload: dict, key: bytes, site: str | None = None):
+        """统一的 AES 签名 POST（对齐参考实现 zhidaoQuery）。
+
+        把 ``dateFormate`` 注入明文，再整体 AES-CBC 加密成 ``secretStr`` 表单字段，同时把
+        ``dateFormate`` 作为顶层明文字段一起发；可按需带 Origin/Referer。
+        """
+        data = dict(payload)
+        ts = int(time.time()) * 1000
+        data["dateFormate"] = ts
+        form = {"secretStr": encrypt_secret_str(data, key=key), "dateFormate": ts}
+        headers = {"Origin": site, "Referer": site + "/"} if site else None
+        return self.session.post(url, data=form, headers=headers, proxies=self.proxies, timeout=10)
 
     def get_course_list(self) -> list[dict]:
-        """获取课程列表（共享课）
+        """获取共享课列表（onlineservice queryShareCourseInfo）。
 
-        Zhihuishu 的 AppInterfaceSign 拦截器现在强制要求 AES 签名参数 ``secretStr``：
-        未签名请求会被拒（code 400 "aes加密参数异常"），导致旧代码读不到数据→空列表。
-        已对真实账号验证：HOME_KEY + secretStr(JSON对象) → code 200，数据在 ``result``
-        下（旧版为 ``rt``）。courseOpenDtos 可能为 null → []。
+        ``secretStr`` 明文必须是分页对象 ``{"status","pageNo","pageSize"}``（不是单纯
+        ``dateFormate``），否则平台返回空集 → 课程"无法加载"。``status`` 0=进行中、1=已完成，
+        两者都要拉取并合并，否则已完成的课加载不出来（实测此即主因）。数据在
+        ``result.courseOpenDtos``，按 ``result.totalCount`` 翻页。每门课的 ``secret`` 即后续视频
+        接口所需的 ``recruitAndCourseId``，这里补成同名字段方便上层使用。
         """
-        url = "https://onlineservice-api.zhihuishu.com/gateway/t/v1/student/course/share/queryShareCourseInfo"
         try:
-            resp = self.session.post(
-                url,
-                data={"secretStr": encrypt_secret_str(key=HOME_KEY)},
-                proxies=self.proxies,
-                timeout=10,
-            )
-            data = resp.json()
-            result = data.get("result") or data.get("rt") or {}
-            return result.get("courseOpenDtos") or []
+            courses: list[dict] = []
+            seen: set[str] = set()
+            for status in COURSE_STATUSES:
+                resp = self._signed_post(
+                    COURSE_LIST_URL,
+                    {"status": status, "pageNo": 1, "pageSize": PAGE_SIZE},
+                    key=HOME_KEY,
+                    site=ONLINEWEB,
+                )
+                result = _extract(resp.json())
+                total = int(result.get("totalCount") or 0)
+                batch = list(result.get("courseOpenDtos") or [])
+                for page in range(2, math.ceil(total / PAGE_SIZE) + 1):
+                    resp = self._signed_post(
+                        COURSE_LIST_URL,
+                        {"status": status, "pageNo": page, "pageSize": PAGE_SIZE},
+                        key=HOME_KEY,
+                        site=ONLINEWEB,
+                    )
+                    batch.extend(_extract(resp.json()).get("courseOpenDtos") or [])
+                for course in batch:
+                    if not isinstance(course, dict):
+                        continue
+                    key = str(course.get("courseId") or course.get("secret") or id(course))
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    if course.get("secret") and not course.get("recruitAndCourseId"):
+                        course["recruitAndCourseId"] = course["secret"]
+                    courses.append(course)
+            return courses
         except Exception as e:
             raise Exception(f"Failed to get course list: {e}")
 
-    def get_video_list(self, course_id: str) -> list[dict]:
-        """获取课程视频列表（studyservice-api）
+    def gologin(self, rac_id: str) -> None:
+        """跨站登录：访问 studyservice 的 gologin 让该域 cookie 生效。
 
-        响应优先读 ``result``，回退 ``rt``（与共享课接口一致的兼容处理）。
-
-        关于签名：只有 onlineservice 的 queryShareCourseInfo 被实证要求 AES `secretStr`
-        签名（HOME_KEY，已验证）。studyservice 这个接口的签名方案未能离线验证（当前账号
-        无共享课可测），故此处不臆造一套很可能错误的签名（HOME_KEY 肯定是错的——它是
-        onlineservice 的密钥）。维持原始明文请求；若线上用真实选课账号发现此接口同样被
-        AppInterfaceSign 拦截（报 "aes加密参数异常/aes解密异常"），正确做法是用
-        studyservice 的视频密钥 ``VIDEO_KEY``（即 self.cipher / saveDatabaseIntervalTime
-        所用密钥）按相同 envelope 签名，而非 HOME_KEY。
+        不先做这一步，后续 studyservice 接口会因 cookie 未对该域生效而失败/空。
         """
-        url = "https://studyservice-api.zhihuishu.com/gateway/t/v1/learning/queryStudyInfo"
+        params = {"fromurl": f"{STUDYH5}/videoStudy.html#/studyVideo?recruitAndCourseId={rac_id}"}
         try:
-            resp = self.session.post(url, json={"recruitAndCourseId": course_id}, proxies=self.proxies, timeout=10)
-            data = resp.json()
-            result = data.get("result") or data.get("rt") or {}
-            return result.get("videoChapterDtos") or []
+            self.session.get(GOLOGIN_URL, params=params, proxies=self.proxies, timeout=10)
+        except Exception as e:  # noqa: BLE001 - gologin 失败不致命，留给后续接口暴露真实错误
+            logger.warning("Zhihuishu gologin failed for %s: %s", rac_id, e)
+
+    def query_course(self, rac_id: str) -> dict:
+        """查询课程信息（含 recruitId、courseInfo.courseId）。"""
+        resp = self._signed_post(QUERY_COURSE_URL, {"recruitAndCourseId": rac_id}, key=VIDEO_KEY, site=STUDYH5)
+        return _extract(resp.json())
+
+    def get_video_list(self, rac_id: str) -> dict:
+        """获取章节/视频树（studyservice videolist）。
+
+        返回 ``data`` 字典：含 ``videoChapterDtos``（章 → ``videoLessons`` → ``videoSmallLessons``）、
+        ``courseId``、``recruitId``。需先 ``gologin`` 让 studyservice 域 cookie 生效，并用
+        ``VIDEO_KEY`` 签名（与共享课列表的 ``HOME_KEY`` 不同）。
+        """
+        try:
+            self.gologin(rac_id)
+            resp = self._signed_post(VIDEO_LIST_URL, {"recruitAndCourseId": rac_id}, key=VIDEO_KEY, site=STUDYH5)
+            return _extract(resp.json())
         except Exception as e:
             raise Exception(f"Failed to get video list: {e}")
 
-    def watch_video(
-        self,
-        course_id: str,
-        video_id: str,
-        duration: int,
-        speed: float = 1.0,
-        is_cancelled=None,
-        is_paused=None,
-    ) -> bool:
+    def query_study_info(self, lesson_ids: list, video_ids: list, recruit_id) -> dict:
+        """查询各（小）节的学习状态（studyservice queryStuyInfo）。
+
+        返回 ``data`` 字典：``lv`` 按 lessonVideoId（小节 id）索引、``lesson`` 按 lessonId 索引，
+        值含 ``studyTotalTime``（已学秒数）与 ``watchState``（1=已完成）。用于让上报从真实进度
+        续播、并跳过已完成视频，避免服务器以 "学习总时长下降了"(code -8) 拒绝。
         """
-        观看视频
+        payload = {"lessonIds": lesson_ids, "lessonVideoIds": video_ids, "recruitId": recruit_id}
+        resp = self._signed_post(QUERY_STUDY_INFO_URL, payload, key=VIDEO_KEY, site=STUDYH5)
+        return _extract(resp.json())
+
+    def _learning_token_id(self, video: dict) -> str | None:
+        """从 prelearningNote 取 learningTokenId（``studiedLessonDto.id`` 的 base64）。"""
+        payload = {
+            "ccCourseId": video.get("course_id"),
+            "chapterId": video.get("chapter_id"),
+            "isApply": 1,
+            "lessonId": video.get("lesson_id"),
+            "lessonVideoId": video.get("small_lesson_id"),
+            "recruitId": video.get("recruit_id"),
+            "videoId": video.get("video_id"),
+        }
+        resp = self._signed_post(PRELEARNING_NOTE_URL, payload, key=VIDEO_KEY, site=STUDYH5)
+        note = _extract(resp.json())
+        token = (note.get("studiedLessonDto") or {}).get("id")
+        if token is None:
+            return None
+        return b64encode(str(token).encode()).decode()
+
+    def _save_progress(self, video: dict, played: float, last_submit: float, watch_point: str, token_id):
+        """上报一次进度（saveDatabaseIntervalTimeV2），返回平台响应 ``code``。
+
+        ``sdsew`` 由 ``get_ev`` 对一组字段（recruitId/lessonId/smallLessonId/videoId/chapterId/…）
+        异或混淆得到，整体再经 ``secretStr`` AES 签名发送。成功码为 0；-8 表示
+        "学习总时长下降了"（上报值低于服务器已记录值），由调用方处理。
+        """
+        video_sec = int(video.get("video_sec") or 0)
+        raw_ev = [
+            video.get("recruit_id"),
+            video.get("lesson_id"),
+            video.get("small_lesson_id"),
+            video.get("video_id"),
+            video.get("chapter_id"),
+            "0",  # studyStatus，固定 0
+            int(played - last_submit),  # 本段播放时长
+            int(played),  # 累计学习时长
+            hms(min(video_sec, int(played))),
+            f"{self.uuid}zhs",
+        ]
+        data = {
+            "ewssw": watch_point,
+            "sdsew": get_ev(raw_ev),
+            "zwsds": token_id,
+            "courseId": video.get("course_id"),
+        }
+        resp = self._signed_post(SAVE_DB_V2_URL, data, key=VIDEO_KEY, site=STUDYH5)
+        return resp.json().get("code")
+
+    def watch_video(self, video: dict, speed: float = 1.0, is_cancelled=None, is_paused=None) -> bool:
+        """真实上报某个视频的学习进度。
 
         Args:
-            course_id: 课程ID
-            video_id: 视频ID
-            duration: 视频时长（秒）
-            speed: 播放倍速（>1 加快，钳制到合理范围以保持上报节奏）
-            is_cancelled: 可选回调，返回 True 时立即中止（响应取消）
-            is_paused: 可选回调，返回 True 时暂停上报（响应暂停）
+            video: ``ZhihuishuAdapter._flatten_videos`` 产出的上下文 dict，含
+                recruit/chapter/lesson/small/video id 与 ``video_sec``。
+            speed: 倍速（钳制到 [0.5, 2.0]）；越大墙钟越短。
+            is_cancelled / is_paused: 可选回调，分别在播放过程中即时中止 / 暂停上报。
 
         Returns:
-            是否成功
+            是否成功（全部分段上报成功）。
         """
-        url = "https://studyservice-api.zhihuishu.com/gateway/t/v1/learning/saveDatabaseIntervalTime"
-
+        video_id = video.get("video_id") or video.get("id")
         try:
-            duration = int(duration or 0)
+            video_sec = int(video.get("video_sec") or video.get("duration") or 0)
         except (TypeError, ValueError):
-            duration = 0
-        if duration <= 0:
-            # 时长缺失/为 0：绝不"秒标完成"。原实现会让 while 一次都不进、直接返回
-            # True，于是视频被记为 100% 却一个观看点都没上报。改为抛错→上层记为失败，
-            # 让进度反映真实情况。(F-zero-duration)
-            raise Exception(f"video {video_id} has no usable duration ({duration!r})")
+            video_sec = 0
+        if video_sec <= 0:
+            # 时长缺失/为 0：绝不"秒标完成"，抛错让上层记为失败。(F-zero-duration)
+            raise Exception(f"video {video_id} has no usable duration ({video_sec!r})")
 
-        # 倍速：以前 watch_video 完全忽略 speed，N 小时课就实打实跑 N 小时。这里把
-        # speed 钳制到 [0.5, 2]，缩短/拉长真实 sleep（studyTime 仍按 5 秒步进上报），
-        # 既支持加速也支持页面提供的 0.5x 慢速，同时保持可信的上报节奏以规避风控。
-        # 下界取 0.5 而非 1.0，否则会把用户选的 0.5x 慢速强行抬回正常速。(F-speed)
+        # 已完成的视频直接跳过（watchState==1），避免无谓上报与 code -8。
+        if int(video.get("watch_state") or 0) == 1:
+            return True
+
         try:
             eff_speed = float(speed)
         except (TypeError, ValueError):
             eff_speed = 1.0
         eff_speed = min(max(eff_speed, 0.5), 2.0)
-        interval = 5
-        sleep_seconds = interval / eff_speed
 
-        watch_point = WatchPoint()
-        current_time = 0
+        # 从服务器记录的已学时长续播：否则上报值会小于已有进度，被判 "学习总时长下降了"(-8)。
+        try:
+            played = float(min(int(video.get("study_total_time") or 0), video_sec))
+        except (TypeError, ValueError):
+            played = 0.0
+        if played >= video_sec:
+            return True
+
+        token_id = self._learning_token_id(video)
+        watch_point = WatchPoint(int(played))
+        last_submit = played
+        elapsed = 0
 
         try:
-            while current_time < duration:
-                # 在每个上报周期开始时检查取消/暂停，使暂停与取消在"播放过程中"即可生效，
-                # 而不必等整段视频跑完。(F-pause-cancel)
+            while played < video_sec:
+                # 每周期开头检查取消/暂停，使其在"播放过程中"即可生效。(F-pause-cancel)
                 if callable(is_cancelled) and is_cancelled():
                     return False
                 while callable(is_paused) and is_paused():
@@ -123,54 +254,62 @@ class ZhihuishuLearning:
                         return False
                     time.sleep(0.3)
 
-                time.sleep(sleep_seconds)
-                current_time += interval
-                watch_point.add(current_time)
+                time.sleep(1)
+                elapsed += 1
+                played = min(played + eff_speed, video_sec)
 
-                data = {
-                    "recruitAndCourseId": course_id,
-                    "videoId": video_id,
-                    "watchPoint": watch_point.get(),
-                    "studyTime": current_time,
-                }
+                if elapsed % 2 == 0:
+                    watch_point.add(int(played))
 
-                encrypted = self.cipher.encrypt(json.dumps(data))
-                resp = self.session.post(url, json={"data": encrypted}, proxies=self.proxies, timeout=10)
-                result = resp.json()
-
-                if result.get("status") != 200:
-                    return False
+                if elapsed % DB_REPORT_INTERVAL == 0 or played >= video_sec:
+                    watch_point.add(int(played))
+                    code = self._save_progress(video, played, last_submit, watch_point.get(), token_id)
+                    if code == -8:
+                        # 服务器已记录 >= 本次上报：该节已学满/被其他端推进，视为完成。
+                        return True
+                    if code not in (0, 200, None):
+                        return False
+                    last_submit = played
+                    watch_point.reset(int(played))
 
             return True
-
         except Exception as e:
             raise Exception(f"Failed to watch video: {e}")
 
-    def complete_course(self, course_id: str) -> dict:
-        """
-        完成整个课程
+    def complete_course(self, rac_id: str) -> dict:
+        """完成整个课程（遍历章节→小节→视频逐个上报）。
 
         Args:
-            course_id: 课程ID
-
-        Returns:
-            完成统计信息
+            rac_id: recruitAndCourseId（共享课列表里每门课的 ``secret``）。
         """
-        videos = self.get_video_list(course_id)
+        data = self.get_video_list(rac_id)
+        recruit_id = data.get("recruitId")
+        course_id = data.get("courseId")
         completed = 0
         failed = 0
 
-        for chapter in videos:
-            for video in chapter.get("videoLearningDtos", []):
-                video_id = video.get("videoId")
-                duration = video.get("videoSec", 0)
-
-                try:
-                    if self.watch_video(course_id, video_id, duration):
-                        completed += 1
-                    else:
+        for chapter in data.get("videoChapterDtos") or []:
+            chapter_id = chapter.get("id") or chapter.get("chapterId")
+            for lesson in chapter.get("videoLessons") or []:
+                lesson_id = lesson.get("id")
+                smalls = lesson.get("videoSmallLessons") or ([lesson] if lesson.get("videoId") else [])
+                for small in smalls:
+                    video = {
+                        "recruit_and_course_id": rac_id,
+                        "recruit_id": recruit_id,
+                        "course_id": course_id,
+                        "chapter_id": chapter_id,
+                        "lesson_id": lesson_id,
+                        "small_lesson_id": 0 if small is lesson else small.get("id"),
+                        "video_id": small.get("videoId"),
+                        "video_sec": small.get("videoSec") or 0,
+                    }
+                    try:
+                        if self.watch_video(video):
+                            completed += 1
+                        else:
+                            failed += 1
+                    except Exception:
                         failed += 1
-                except Exception:
-                    failed += 1
 
         return {"completed": completed, "failed": failed, "total": completed + failed}

--- a/backend/tests/unit/test_zhihuishu_adapter.py
+++ b/backend/tests/unit/test_zhihuishu_adapter.py
@@ -1,54 +1,78 @@
-"""Unit tests for ZhihuishuAdapter._run_task_loop driving the real study flow.
+"""Unit tests for ZhihuishuAdapter._run_task_loop and the ZhihuishuLearning
+request protocol.
 
-These tests mock the Zhihuishu HTTP layer (ZhihuishuLearning / ZhihuishuAnswer)
-so they assert that the worker loop actually CALLS watch_video / answer_question
-and reflects the mocked platform responses in progress -- instead of running a
-fake timer that fabricates a 'completed' status.
+The adapter tests mock the Zhihuishu HTTP layer (ZhihuishuLearning / ZhihuishuAnswer)
+so they assert the worker loop actually CALLS watch_video / answer_question and
+reflects the mocked platform responses in progress -- instead of running a fake
+timer that fabricates a 'completed' status.
+
+The protocol tests pin the corrected request shapes against the live API
+(queryShareCourseInfo pagination payload, videolist endpoint + VIDEO_KEY signing)
+without needing real credentials.
 
 NOTE: End-to-end verification against the live Zhihuishu platform requires real
-credentials, which are not available in this environment. These unit tests pin
-the behavioural contract (real method invocation + progress derived from real
-responses) at the seam between the adapter and the HTTP services.
+credentials, which are not available in this environment.
 """
 
+import json
 import threading
 import time
 
 import pytest
 
 from app.services.course.zhihuishu.adapter import ZhihuishuAdapter
+from app.services.course.zhihuishu.crypto import HOME_KEY, VIDEO_KEY, Cipher
+from app.services.course.zhihuishu.learning import ZhihuishuLearning
+
+
+def _chapters(*videos, course_id="cc-1", recruit_id="r-1"):
+    """Build a realistic videolist ``data`` dict.
+
+    Each entry is ``(video_id, name, sec)`` or ``(video_id, name, sec, questions)``;
+    rendered as a single-video lesson (``videoId`` on the lesson, no
+    ``videoSmallLessons``) under one chapter.
+    """
+    lessons = []
+    for v in videos:
+        vid, name, sec = v[0], v[1], v[2]
+        lesson = {"id": f"L{vid}", "name": name, "videoId": vid, "videoSec": sec}
+        if len(v) > 3 and v[3]:
+            lesson["questionList"] = v[3]
+        lessons.append(lesson)
+    return {
+        "courseId": course_id,
+        "recruitId": recruit_id,
+        "videoChapterDtos": [{"id": "ch1", "name": "Chapter 1", "videoLessons": lessons}],
+    }
 
 
 class FakeLearning:
     """Stand-in for ZhihuishuLearning that records watch_video calls."""
 
-    def __init__(self, chapters, watch_results=None):
-        self._chapters = chapters
+    def __init__(self, data, watch_results=None):
+        self._data = data
         # watch_results: optional mapping video_id -> bool (default True)
         self._watch_results = watch_results or {}
         self.watch_calls = []
         self.lock = threading.Lock()
 
-    def get_video_list(self, course_id):
-        return self._chapters
+    def get_video_list(self, rac_id):
+        return self._data
 
-    def watch_video(self, course_id, video_id, duration, speed=1.0,
-                    is_cancelled=None, is_paused=None):
+    def watch_video(self, video, speed=1.0, is_cancelled=None, is_paused=None):
         # Signature mirrors the real ZhihuishuLearning.watch_video: the adapter now
-        # forwards speed + pause/cancel checkers so a long video honors倍速 and
-        # reacts mid-playback. Record them so tests can assert the contract.
+        # forwards the full video-context dict + speed + pause/cancel checkers.
         with self.lock:
             self.watch_calls.append(
                 {
-                    "course_id": course_id,
-                    "video_id": video_id,
-                    "duration": duration,
+                    "video_id": video.get("video_id"),
+                    "duration": video.get("video_sec") if video.get("video_sec") is not None else video.get("duration"),
                     "speed": speed,
                     "is_cancelled": is_cancelled,
                     "is_paused": is_paused,
                 }
             )
-        return self._watch_results.get(str(video_id), True)
+        return self._watch_results.get(str(video.get("video_id")), True)
 
 
 class FakeAnswer:
@@ -67,9 +91,9 @@ class FakeAnswer:
         return "A"
 
 
-def _make_adapter(chapters, watch_results=None, ai_enabled=True):
+def _make_adapter(data, watch_results=None, ai_enabled=True):
     adapter = ZhihuishuAdapter(ai_config={"enabled": ai_enabled})
-    adapter.learning = FakeLearning(chapters, watch_results=watch_results)
+    adapter.learning = FakeLearning(data, watch_results=watch_results)
     adapter.answer = FakeAnswer(ai_enabled=ai_enabled)
     return adapter
 
@@ -93,15 +117,7 @@ def _wait_for_terminal(adapter, course_id, timeout=5.0):
 
 
 def test_loop_calls_watch_video_for_every_video():
-    chapters = [
-        {
-            "videoLearningDtos": [
-                {"videoId": "v1", "videoName": "Intro", "videoSec": 10},
-                {"videoId": "v2", "videoName": "Body", "videoSec": 20},
-            ]
-        }
-    ]
-    adapter = _make_adapter(chapters, ai_enabled=False)
+    adapter = _make_adapter(_chapters(("v1", "Intro", 10), ("v2", "Body", 20)), ai_enabled=False)
 
     result = adapter.start_course("c-1", speed=1.0, auto_answer=False)
     assert result["task_id"]
@@ -123,15 +139,9 @@ def test_loop_calls_watch_video_for_every_video():
 
 def test_progress_reflects_failed_watch_response():
     """A False watch_video response must be reflected as a failed video, not faked success."""
-    chapters = [
-        {
-            "videoLearningDtos": [
-                {"videoId": "v1", "videoName": "Ok", "videoSec": 5},
-                {"videoId": "v2", "videoName": "Fails", "videoSec": 5},
-            ]
-        }
-    ]
-    adapter = _make_adapter(chapters, watch_results={"v2": False}, ai_enabled=False)
+    adapter = _make_adapter(
+        _chapters(("v1", "Ok", 5), ("v2", "Fails", 5)), watch_results={"v2": False}, ai_enabled=False
+    )
 
     adapter.start_course("c-2", speed=1.0, auto_answer=False)
     progress = _wait_for_terminal(adapter, "c-2")
@@ -146,19 +156,7 @@ def test_progress_reflects_failed_watch_response():
 def test_loop_answers_questions_when_auto_answer_enabled():
     q1 = {"title": "Q1", "choices": [{"name": "A", "content": "x"}]}
     q2 = {"title": "Q2", "choices": [{"name": "B", "content": "y"}]}
-    chapters = [
-        {
-            "videoLearningDtos": [
-                {
-                    "videoId": "v1",
-                    "videoName": "Has quiz",
-                    "videoSec": 5,
-                    "questionList": [q1, q2],
-                }
-            ]
-        }
-    ]
-    adapter = _make_adapter(chapters, ai_enabled=True)
+    adapter = _make_adapter(_chapters(("v1", "Has quiz", 5, [q1, q2])), ai_enabled=True)
 
     adapter.start_course("c-3", speed=1.0, auto_answer=True)
     progress = _wait_for_terminal(adapter, "c-3")
@@ -171,19 +169,7 @@ def test_loop_answers_questions_when_auto_answer_enabled():
 
 def test_loop_skips_answering_when_auto_answer_disabled():
     q1 = {"title": "Q1", "choices": []}
-    chapters = [
-        {
-            "videoLearningDtos": [
-                {
-                    "videoId": "v1",
-                    "videoName": "Has quiz",
-                    "videoSec": 5,
-                    "questionList": [q1],
-                }
-            ]
-        }
-    ]
-    adapter = _make_adapter(chapters, ai_enabled=True)
+    adapter = _make_adapter(_chapters(("v1", "Has quiz", 5, [q1])), ai_enabled=True)
 
     adapter.start_course("c-4", speed=1.0, auto_answer=False)
     _wait_for_terminal(adapter, "c-4")
@@ -196,27 +182,15 @@ def test_cancel_stops_loop_before_remaining_videos():
     started = threading.Event()
     release = threading.Event()
 
-    chapters = [
-        {
-            "videoLearningDtos": [
-                {"videoId": "v1", "videoName": "A", "videoSec": 5},
-                {"videoId": "v2", "videoName": "B", "videoSec": 5},
-            ]
-        }
-    ]
-    adapter = _make_adapter(chapters, ai_enabled=False)
+    adapter = _make_adapter(_chapters(("v1", "A", 5), ("v2", "B", 5)), ai_enabled=False)
 
     real_watch = adapter.learning.watch_video
 
-    def blocking_watch(course_id, video_id, duration, speed=1.0,
-                       is_cancelled=None, is_paused=None):
-        if video_id == "v1":
+    def blocking_watch(video, speed=1.0, is_cancelled=None, is_paused=None):
+        if video.get("video_id") == "v1":
             started.set()
             release.wait(timeout=5)
-        return real_watch(
-            course_id, video_id, duration, speed=speed,
-            is_cancelled=is_cancelled, is_paused=is_paused,
-        )
+        return real_watch(video, speed=speed, is_cancelled=is_cancelled, is_paused=is_paused)
 
     adapter.learning.watch_video = blocking_watch
 
@@ -235,8 +209,7 @@ def test_cancel_stops_loop_before_remaining_videos():
 
 def test_watch_video_receives_speed_and_control_callbacks():
     """The adapter must forward speed and working pause/cancel checkers (F-speed/F-pause-cancel)."""
-    chapters = [{"videoLearningDtos": [{"videoId": "v1", "videoName": "A", "videoSec": 5}]}]
-    adapter = _make_adapter(chapters, ai_enabled=False)
+    adapter = _make_adapter(_chapters(("v1", "A", 5)), ai_enabled=False)
 
     adapter.start_course("c-speed", speed=1.75, auto_answer=False)
     _wait_for_terminal(adapter, "c-speed")
@@ -254,14 +227,15 @@ def test_zero_duration_video_not_faked_complete():
     """A 0/None-duration video must NOT be counted as completed (F-zero-duration).
 
     Uses the REAL ZhihuishuLearning.watch_video (no watch_video override) to
-    exercise the duration guard; get_video_list is stubbed.
+    exercise the duration guard; get_video_list / get_course_list are stubbed so
+    no network call happens.
     """
-    from app.services.course.zhihuishu.learning import ZhihuishuLearning
-
-    chapters = [{"videoLearningDtos": [{"videoId": "v0", "videoName": "NoDur", "videoSec": 0}]}]
+    data = _chapters(("v0", "NoDur", 0))
     adapter = ZhihuishuAdapter(ai_config={"enabled": False})
     real_learning = ZhihuishuLearning(cookies={}, proxies={})
-    real_learning.get_video_list = lambda course_id: chapters
+    real_learning.get_course_list = lambda: []  # avoid network in _resolve_rac_id
+    real_learning.get_video_list = lambda rac_id: data
+    real_learning.query_study_info = lambda *a, **k: {}  # avoid network in _annotate_watch_state
     adapter.learning = real_learning
 
     adapter.start_course("c-zero", speed=1.0, auto_answer=False)
@@ -271,6 +245,224 @@ def test_zero_duration_video_not_faked_complete():
     assert progress["completed"] == 0
     assert progress["failed"] == 1
     assert progress["percentage"] == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# Request-protocol tests (the actual "课程无法加载" fix)
+# --------------------------------------------------------------------------- #
+
+
+class _Resp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def test_get_course_list_signs_pagination_payload_for_both_statuses():
+    """Course list must POST a HOME_KEY-signed {status,pageNo,pageSize} secretStr for
+    BOTH status 0 (进行中) and 1 (已完成) — the old code sent only {dateFormate} for
+    status 0, so a finished course never loaded (the real "课程无法加载" cause)."""
+    learning = ZhihuishuLearning(cookies={}, proxies={})
+    calls = []
+
+    def fake_post(url, data=None, headers=None, proxies=None, timeout=None):
+        calls.append({"url": url, "data": data, "headers": headers})
+        return _Resp(
+            {
+                "code": 200,
+                "result": {
+                    "totalCount": 1,
+                    "courseOpenDtos": [{"courseId": "c1", "courseName": "A", "secret": "sec1"}],
+                },
+            }
+        )
+
+    learning.session.post = fake_post
+    courses = learning.get_course_list()
+
+    statuses = set()
+    for c in calls:
+        assert "queryShareCourseInfo" in c["url"]
+        obj = json.loads(Cipher(HOME_KEY).decrypt(c["data"]["secretStr"]))
+        assert obj["pageNo"] == 1 and obj["pageSize"] == 5
+        assert "dateFormate" in obj  # signing layer injects the timestamp into the plaintext
+        assert c["data"]["dateFormate"]  # ...and as a sibling top-level form field
+        assert c["headers"]["Origin"] == "https://onlineweb.zhihuishu.com"
+        statuses.add(obj["status"])
+    # Both 进行中 and 已完成 must be queried.
+    assert statuses == {0, 1}
+    # Same course returned under both statuses is de-duplicated by courseId.
+    assert len(courses) == 1
+    # secret is normalized to recruitAndCourseId for downstream video calls.
+    assert courses[0]["recruitAndCourseId"] == "sec1"
+
+
+def test_query_study_info_signs_with_video_key():
+    """Watch-state lookup must POST a VIDEO_KEY-signed secretStr to queryStuyInfo."""
+    learning = ZhihuishuLearning(cookies={}, proxies={}, uuid="u")
+    captured = {}
+
+    def fake_post(url, data=None, headers=None, proxies=None, timeout=None):
+        captured["url"] = url
+        captured["data"] = data
+        return _Resp({"code": 0, "data": {"lv": {"5": {"studyTotalTime": 100, "watchState": 1}}, "lesson": {}}})
+
+    learning.session.post = fake_post
+    info = learning.query_study_info(["L1"], ["5"], "R")
+
+    assert "queryStuyInfo" in captured["url"]
+    obj = json.loads(Cipher(VIDEO_KEY).decrypt(captured["data"]["secretStr"]))
+    assert obj["recruitId"] == "R" and obj["lessonIds"] == ["L1"] and obj["lessonVideoIds"] == ["5"]
+    assert info["lv"]["5"]["watchState"] == 1
+
+
+def test_watch_video_skips_completed_video_without_network():
+    """watchState==1 videos are skipped (counted done) with zero HTTP."""
+    learning = ZhihuishuLearning(cookies={}, proxies={})
+
+    def boom(*a, **k):
+        raise AssertionError("no HTTP should happen for an already-completed video")
+
+    learning.session.post = boom
+    learning.session.get = boom
+    video = {
+        "video_id": "v", "video_sec": 100, "watch_state": 1, "study_total_time": 100,
+        "small_lesson_id": 0, "lesson_id": "L", "chapter_id": "C", "recruit_id": "R", "course_id": "CC",
+    }
+    assert learning.watch_video(video) is True
+
+
+def test_watch_video_resumes_from_study_total_time(monkeypatch):
+    """Reports must resume from the server's studyTotalTime, never restart at 0
+    (else the first report is < recorded time → code -8)."""
+    import app.services.course.zhihuishu.learning as learning_mod
+
+    monkeypatch.setattr(learning_mod.time, "sleep", lambda *_: None)
+    learning = ZhihuishuLearning(cookies={}, proxies={}, uuid="u")
+    learning._learning_token_id = lambda video: "tok"
+    reports = []
+
+    def fake_save(video, played, last_submit, watch_point, token_id):
+        reports.append({"played": played, "last_submit": last_submit, "token": token_id})
+        return 0
+
+    learning._save_progress = fake_save
+    video = {
+        "video_id": "v", "video_sec": 10, "study_total_time": 4, "watch_state": 0,
+        "small_lesson_id": 0, "lesson_id": "L", "chapter_id": "C", "recruit_id": "R", "course_id": "CC",
+    }
+    assert learning.watch_video(video, speed=2.0) is True
+    assert reports, "should have reported at least once"
+    assert reports[0]["last_submit"] >= 4  # resumed from prior progress, not 0
+    assert all(r["token"] == "tok" for r in reports)
+
+
+def test_watch_video_treats_code_minus8_as_already_complete(monkeypatch):
+    """A -8 ('学习总时长下降了') means the server is already ahead → treat as done, not failed."""
+    import app.services.course.zhihuishu.learning as learning_mod
+
+    monkeypatch.setattr(learning_mod.time, "sleep", lambda *_: None)
+    learning = ZhihuishuLearning(cookies={}, proxies={}, uuid="u")
+    learning._learning_token_id = lambda video: "tok"
+    learning._save_progress = lambda *a, **k: -8
+    video = {
+        "video_id": "v", "video_sec": 10, "study_total_time": 0, "watch_state": 0,
+        "small_lesson_id": 0, "lesson_id": "L", "chapter_id": "C", "recruit_id": "R", "course_id": "CC",
+    }
+    assert learning.watch_video(video, speed=2.0) is True
+
+
+def test_annotate_watch_state_maps_study_info():
+    """Adapter must map lv (by small-lesson id) and lesson (by lesson id) onto videos."""
+
+    class _L:
+        def query_study_info(self, lesson_ids, video_ids, recruit_id):
+            return {
+                "lv": {"sm": {"studyTotalTime": 50, "watchState": 0}},
+                "lesson": {"L1": {"studyTotalTime": 99, "watchState": 1}},
+            }
+
+    adapter = ZhihuishuAdapter(ai_config={"enabled": False})
+    adapter.learning = _L()
+    videos = [
+        {"small_lesson_id": "sm", "lesson_id": "Lx"},  # matched via lv
+        {"small_lesson_id": 0, "lesson_id": "L1"},  # single-video lesson, matched via lesson
+    ]
+    adapter._annotate_watch_state(videos, {"recruitId": "R"})
+    assert videos[0]["study_total_time"] == 50 and videos[0]["watch_state"] == 0
+    assert videos[1]["study_total_time"] == 99 and videos[1]["watch_state"] == 1
+
+
+def test_get_video_list_uses_videolist_endpoint_and_video_key():
+    """Chapter list must gologin then POST a VIDEO_KEY-signed secretStr to
+    .../learning/videolist and read data.videoChapterDtos."""
+    learning = ZhihuishuLearning(cookies={}, proxies={}, uuid="u1")
+    calls = []
+
+    def fake_get(url, params=None, proxies=None, timeout=None):
+        calls.append(("GET", url))
+        return _Resp({})
+
+    def fake_post(url, data=None, headers=None, proxies=None, timeout=None):
+        calls.append(("POST", url, data))
+        return _Resp({"data": {"courseId": "cc", "recruitId": "rr", "videoChapterDtos": []}})
+
+    learning.session.get = fake_get
+    learning.session.post = fake_post
+
+    data = learning.get_video_list("rac1")
+
+    # gologin (cross-site) must happen first
+    assert calls[0][0] == "GET" and "gologin" in calls[0][1]
+    post = next(c for c in calls if c[0] == "POST")
+    assert "videolist" in post[1]
+    obj = json.loads(Cipher(VIDEO_KEY).decrypt(post[2]["secretStr"]))
+    assert obj["recruitAndCourseId"] == "rac1"
+    assert data["courseId"] == "cc"
+
+
+def test_flatten_videos_parses_nested_small_lessons():
+    """videoChapterDtos[].videoLessons[].videoSmallLessons[] must flatten with full context."""
+    data = {
+        "courseId": "cc",
+        "recruitId": "rr",
+        "videoChapterDtos": [
+            {
+                "id": "chap",
+                "videoLessons": [
+                    {
+                        "id": "lesson",
+                        "name": "L",
+                        "videoSmallLessons": [
+                            {"id": "small", "videoId": "vid", "videoSec": 42, "name": "small-v"},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    videos = ZhihuishuAdapter._flatten_videos(data, rac_id="rac1")
+    assert len(videos) == 1
+    v = videos[0]
+    assert v["video_id"] == "vid"
+    assert v["video_sec"] == 42
+    assert v["chapter_id"] == "chap"
+    assert v["lesson_id"] == "lesson"
+    assert v["small_lesson_id"] == "small"
+    assert v["recruit_id"] == "rr"
+    assert v["course_id"] == "cc"
+    assert v["recruit_and_course_id"] == "rac1"
+
+
+def test_flatten_videos_single_video_lesson_gets_zero_small_lesson_id():
+    data = _chapters(("v1", "Solo", 7))
+    videos = ZhihuishuAdapter._flatten_videos(data, rac_id="rac1")
+    assert len(videos) == 1
+    assert videos[0]["small_lesson_id"] == 0
+    assert videos[0]["lesson_id"] == "Lv1"
+    assert videos[0]["video_id"] == "v1"
 
 
 if __name__ == "__main__":

--- a/backend/tests/unit/test_zhihuishu_crypto.py
+++ b/backend/tests/unit/test_zhihuishu_crypto.py
@@ -1,0 +1,53 @@
+"""Unit tests for the Zhihuishu crypto helpers (AES secretStr signing + ev/sdsew
+XOR obfuscation) that the corrected request protocol relies on."""
+
+import json
+
+from app.services.course.zhihuishu.crypto import (
+    HOME_KEY,
+    VIDEO_KEY,
+    Cipher,
+    encrypt_secret_str,
+    get_ev,
+    hms,
+)
+
+
+def test_get_ev_matches_reference_vector():
+    """get_ev(';'.join) XOR-cycles the key 'zzpttjd' and emits 2-hex pairs.
+
+    '1;2' XOR [122,122,112] => 0x4b,0x41,0x42 => '4b4142' (hand-computed against
+    the upstream reference implementation).
+    """
+    assert get_ev(["1", "2"]) == "4b4142"
+    # Non-string fields are stringified the same way (1 -> "1").
+    assert get_ev([1, 2]) == "4b4142"
+
+
+def test_get_ev_is_deterministic_and_hex():
+    ev = get_ev(["recruit", "lesson", 0, "vid"])
+    assert ev == get_ev(["recruit", "lesson", 0, "vid"])
+    assert all(c in "0123456789abcdef" for c in ev)
+    assert len(ev) % 2 == 0
+
+
+def test_hms_formats_seconds():
+    assert hms(65) == "0:01:05"
+    assert hms(3661) == "1:01:01"
+    assert hms(0) == "0:00:00"
+
+
+def test_course_list_secret_str_roundtrips_under_home_key():
+    payload = {"status": 0, "pageNo": 1, "pageSize": 5}
+    secret = encrypt_secret_str(payload, key=HOME_KEY)
+    decoded = json.loads(Cipher(HOME_KEY).decrypt(secret))
+    assert decoded == payload
+
+
+def test_video_secret_str_uses_distinct_key():
+    payload = {"recruitAndCourseId": "rac-1"}
+    secret = encrypt_secret_str(payload, key=VIDEO_KEY)
+    # Correct key decrypts cleanly...
+    assert json.loads(Cipher(VIDEO_KEY).decrypt(secret)) == payload
+    # ...and the two endpoint keys are genuinely different.
+    assert HOME_KEY != VIDEO_KEY

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "university-helper-frontend",
   "private": true,
-  "version": "1.2.1",
+  "version": "1.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 # Release this one-click installer targets. Bump alongside backend/app/main.py
 # and frontend/package.json when cutting a new version.
-APP_VERSION="1.2.1"
+APP_VERSION="1.2.2"
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT_DIR"


### PR DESCRIPTION
## Problem
知到/智慧树 courses failed to load ("课程无法加载"). The zhihuishu module was ported from [`VermiIIi0n/fuckZHS`](https://github.com/VermiIIi0n/fuckZHS) (crypto keys/IV/Cipher are byte-identical) but kept **stale/incorrect call protocols**. Compared against 3 reference projects (fuckZHS 2025-10-29 is authoritative & still working) and **verified live against an authorized real 知到 account**.

## Root cause (found via live 联调)
`get_course_list` hardcoded `status:0` (进行中). The account's only 共享课 was **`status:1` (已完成, 100%)** → silently dropped → empty list. (A prior audit mis-read the empty result as "account has no courses".)

## Fixes
- **① Course list** (`queryShareCourseInfo`): query **both `status` 0 and 1** and merge by `courseId`; sign `{status,pageNo,pageSize}` with HOME_KEY + top-level `dateFormate` + `onlineweb` Origin/Referer; paginate by `totalCount`; normalize `secret` → `recruitAndCourseId`.
- **② Chapter/video list**: `queryStudyInfo` → **`videolist`**; VIDEO_KEY-signed `secretStr`; `gologin` cross-site bootstrap; read **`data.videoChapterDtos`**; pass `recruitAndCourseId` (not `courseId`); flatten `videoLessons` / `videoSmallLessons`.
- **③ Progress report**: rewrite to real **`saveDatabaseIntervalTimeV2`** (`get_ev`/`sdsew` + `prelearningNote` `learningTokenId` + full video context/uuid). Add **`queryStuyInfo`** so `watch_video` resumes from `studyTotalTime`, skips `watchState==1`, and treats `code -8` ("学习总时长下降了") as already-complete.
- `crypto.py`: add `get_ev` (XOR obfuscation) + `hms`; keys/IV unchanged.

## Live validation (authorized real account)
- `get_grouped_courses()` → course **now appears** (大学生心理健康, 100%).
- `get_videos()` → **4 chapters / 78 videos** parsed, annotated with watch state.
- `saveDatabaseIntervalTimeV2` accepted by the server's signing/parse layer (the `-8` was business logic for an already-100% course).

## Tests
- **21 zhihuishu unit tests** green (`test_zhihuishu_adapter.py` + new `test_zhihuishu_crypto.py`): request shapes, `secretStr` round-trip, flatten, status 0+1 merge, resume/skip/-8, `queryStuyInfo`, annotate.
- Full suite: 240 passed; the 9 failures are pre-existing notification SSRF-allowlist tests, unrelated to this change.

Bumps version **1.2.1 → 1.2.2** (main.py + frontend/package.json + setup.sh).