### PR TITLE
style(zhihuishu): ruff format adapter.py (fix CI format check)

### DIFF
--- a/backend/app/services/course/zhihuishu/adapter.py
+++ b/backend/app/services/course/zhihuishu/adapter.py
@@ -424,9 +424,7 @@ class ZhihuishuAdapter:
         index = 1
         for chapter in chapters:
             chapter_id = chapter.get("id") or chapter.get("chapterId")
-            lessons = (
-                chapter.get("videoLessons") or chapter.get("videoLearningDtos") or chapter.get("videoDtos") or []
-            )
+            lessons = chapter.get("videoLessons") or chapter.get("videoLearningDtos") or chapter.get("videoDtos") or []
             for lesson in lessons:
                 lesson_id = lesson.get("id") or lesson.get("lessonId")
                 smalls = lesson.get("videoSmallLessons") or [lesson]


### PR DESCRIPTION
Behavior-identical formatting fix: `ruff format` (0.8.4, the CI-pinned version) reflows one wrapped line in `adapter.py` to its canonical single-line form so `ruff format --check app/` passes. Follow-up to #21 (v1.2.2). `ruff check app/` and the 21 zhihuishu unit tests pass.