### PR TITLE
feat(tiku): GO题库 + 多题库回退 + LocalCache（补全题库功能）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **题库 (answer-bank) parity with upstream + multi-题库 fallback.** Ported the
+  **GO 题库** (`TikuGo`, free `q.icodef.com` search source) from
+  [Samueli924/chaoxing](https://github.com/Samueli924/chaoxing) and added a
+  **多题库回退** chain: `tiku_config.provider` now accepts a comma-separated,
+  ordered list and the worker falls through to the next bank when one misses or
+  returns a type-mismatched answer. Providers that fail to initialize (token-less
+  bank, key-less LLM) are dropped from the chain automatically. A chain ending in
+  an LLM keeps the AI judgement-normalization behaviour of a direct LLM selection.
+- **本地缓存题库 (`LocalCache`)** provider — the frontend already listed a "本地缓存"
+  option but the backend factory didn't register it (selecting it silently
+  disabled answering). It now works as a real token-free, cache-only source.
+- Fanya **题库来源** picker is now multi-select with explicit ①②③ fallback order;
+  the default chain `言溪 → GO题库` answers even without a Token.
+- README (EN + zh-CN) gains an **Answer banks (题库)** section documenting every
+  source, which need a token, and how to configure a fallback chain.
+
 ## [1.2.1] - 2026-06-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -105,6 +105,37 @@ automatically by the docker entrypoint. Alembic migrations live in
 `POST /api/v1/course/start` · `GET /api/v1/course/status/{task_id}`
 `POST /api/v1/course/zhihuishu/{qr-login,password-login,tasks/course}`
 
+## Answer banks (题库)
+
+When auto-answering Chaoxing quizzes, the worker resolves each question through a
+configurable **answer bank** (`tiku`). The chosen answer is checked against the
+question type and cached, so a quiz of N questions does O(1) cache reads. Set the
+source(s) under `tiku_config.provider` (the Fanya page surfaces this as **题库来源**).
+
+| Provider | `provider` value | Token | Notes |
+|----------|------------------|-------|-------|
+| 言溪题库 | `TikuYanxi` | required | General-purpose bank. |
+| GO 题库 | `TikuGo` | optional | Free search source (网课小工具, `q.icodef.com`); throttled. |
+| Like 题库 | `TikuLike` | required | Backup bank (datam.site). |
+| 题库适配器 | `TikuAdapter` | — | Points at a self-hosted [tikuAdapter](https://github.com/DokiDoki1103/tikuAdapter) (`url`). |
+| AI 智能答题 | `AI` | — | OpenAI-compatible LLM (`endpoint`/`key`/`model`). |
+| 硅基流动 | `SiliconFlow` | required | SiliconFlow LLM. |
+| 本地缓存 | `LocalCache` | — | Cache-only; never calls an external API. |
+
+**多题库回退 (fallback chain).** `provider` accepts a comma-separated, ordered
+list — the worker tries each in turn and falls through to the next when one
+misses or returns a type-mismatched answer. Providers that can't initialize
+(e.g. a token-less bank, or an LLM with no key) are dropped from the chain
+automatically, so a mixed chain stays usable as long as one link works.
+
+```jsonc
+// tiku_config — try 言溪 first, then fall back to the free GO题库
+{ "provider": "TikuYanxi,TikuGo", "token": "<yanxi-token>" }
+```
+
+> The shared answer cache is always consulted before any provider, so the
+> `LocalCache` source only adds value when selected on its own (cache-only mode).
+
 ## Deployment
 
 > **Single source of truth: [`docs/DEPLOYMENT.md`](./docs/DEPLOYMENT.md).**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -55,6 +55,33 @@ scripts/        安装、测试、备份、部署脚本
 - `POST /api/v1/course/zhihuishu/password-login`
 - `POST /api/v1/course/zhihuishu/tasks/course`
 
+## 题库
+
+自动答题时，每道题都会经过一个可配置的**题库**（`tiku`）查询。命中的答案会按题型
+校验并写入缓存，因此一份 N 题的试卷只需 O(1) 次缓存读取。题库来源通过
+`tiku_config.provider` 配置（泛雅页面对应「题库来源」）。
+
+| 题库 | `provider` 取值 | Token | 说明 |
+|------|----------------|-------|------|
+| 言溪题库 | `TikuYanxi` | 需要 | 通用题库。 |
+| GO 题库 | `TikuGo` | 可选 | 免费搜题源（网课小工具，`q.icodef.com`），有节流。 |
+| Like 题库 | `TikuLike` | 需要 | 备用题库（datam.site）。 |
+| 题库适配器 | `TikuAdapter` | — | 指向自建的 [tikuAdapter](https://github.com/DokiDoki1103/tikuAdapter)（`url`）。 |
+| AI 智能答题 | `AI` | — | OpenAI 兼容大模型（`endpoint`/`key`/`model`）。 |
+| 硅基流动 | `SiliconFlow` | 需要 | 硅基流动大模型。 |
+| 本地缓存 | `LocalCache` | — | 仅用已缓存答案，从不调用外部 API。 |
+
+**多题库回退。** `provider` 支持逗号分隔的有序列表：前一个未命中或返回的答案类型
+不符时，自动回退到下一个。无法初始化的题库（如缺 Token 的题库、缺 key 的大模型）
+会被自动从回退链中剔除，因此只要链中有一个可用，整条链就仍然有效。
+
+```jsonc
+// tiku_config —— 先言溪，未命中再用免费的 GO题库 兜底
+{ "provider": "TikuYanxi,TikuGo", "token": "<言溪 token>" }
+```
+
+> 答案缓存总会在所有题库之前先查一次，因此 `LocalCache` 仅在单独选用（纯缓存模式）时才有意义，放进回退链里是冗余的。
+
 ## 本地开发
 
 ### 1. 后端

--- a/backend/app/services/course/chaoxing/answer.py
+++ b/backend/app/services/course/chaoxing/answer.py
@@ -3,12 +3,31 @@
 All implementation has been split into:
 - answer_utils.py       (utility functions)
 - answer_cache.py       (CacheDAO)
-- answer_base.py        (Tiku base class)
-- answer_providers/     (TikuYanxi, TikuLike, TikuAdapter, AI, SiliconFlow)
+- answer_base.py        (Tiku base class, TikuFallback)
+- answer_providers/     (TikuYanxi, TikuGo, TikuLike, TikuAdapter, TikuLocalCache, AI, SiliconFlow)
 """
 
-from .answer_base import Tiku
+from .answer_base import Tiku, TikuFallback
 from .answer_cache import CacheDAO
-from .answer_providers import AI, SiliconFlow, TikuAdapter, TikuLike, TikuYanxi
+from .answer_providers import (
+    AI,
+    SiliconFlow,
+    TikuAdapter,
+    TikuGo,
+    TikuLike,
+    TikuLocalCache,
+    TikuYanxi,
+)
 
-__all__ = ["CacheDAO", "Tiku", "TikuYanxi", "TikuLike", "TikuAdapter", "AI", "SiliconFlow"]
+__all__ = [
+    "CacheDAO",
+    "Tiku",
+    "TikuFallback",
+    "TikuYanxi",
+    "TikuGo",
+    "TikuLike",
+    "TikuAdapter",
+    "TikuLocalCache",
+    "AI",
+    "SiliconFlow",
+]

--- a/backend/app/services/course/chaoxing/answer_base.py
+++ b/backend/app/services/course/chaoxing/answer_base.py
@@ -238,24 +238,54 @@ class Tiku:
             self.DISABLE = True
             logger.info("未找到题库配置, 已忽略题库功能")
             return self
-        # FIXME: Implement using StrEnum instead. This is not only buggy but also not safe
         # Import providers at runtime to build the lookup (avoids circular imports)
-        from .answer_providers import AI, SiliconFlow, TikuAdapter, TikuLike, TikuYanxi
+        from .answer_providers import (
+            AI,
+            SiliconFlow,
+            TikuAdapter,
+            TikuGo,
+            TikuLike,
+            TikuLocalCache,
+            TikuYanxi,
+        )
 
         _provider_map = {
             "TikuYanxi": TikuYanxi,
+            "TikuGo": TikuGo,
             "TikuLike": TikuLike,
             "TikuAdapter": TikuAdapter,
+            "LocalCache": TikuLocalCache,
             "AI": AI,
             "SiliconFlow": SiliconFlow,
         }
-        if cls_name not in _provider_map:
+
+        # provider 支持逗号分隔的多题库回退链：单个 → 直接返回该题库；
+        # 多个 → 构造 TikuFallback，按配置顺序逐个兜底。
+        names = [name.strip() for name in str(cls_name).split(",") if name.strip()]
+        if not names:
             self.DISABLE = True
-            logger.error(f"未知的题库 provider: {cls_name}")
+            logger.error("题库 provider 配置为空, 已忽略题库功能")
             return self
-        new_cls = _provider_map[cls_name]()
-        new_cls.config_set(self._conf)
-        return new_cls
+
+        unknown = [name for name in names if name not in _provider_map]
+        if unknown:
+            self.DISABLE = True
+            logger.error(f"未知的题库 provider: {', '.join(unknown)}")
+            return self
+
+        if len(names) == 1:
+            new_cls = _provider_map[names[0]]()
+            new_cls.config_set(self._conf)
+            return new_cls
+
+        chain = []
+        for name in names:
+            provider = _provider_map[name]()
+            provider.config_set(self._conf)
+            chain.append(provider)
+        fallback = TikuFallback(chain)
+        fallback.config_set(self._conf)
+        return fallback
 
     def judgement_select(self, answer: str) -> bool:
         """
@@ -284,3 +314,128 @@ class Tiku:
         if self.SUBMIT:
             return ""
         return "1"
+
+    @property
+    def wants_concurrent_query(self) -> bool:
+        """Whether a card's questions should be answered concurrently.
+
+        Only the AI provider opts in — it is built for it (each request is bounded
+        by its own semaphore). Other providers (incl. SiliconFlow) stay sequential,
+        preserving existing behaviour. TikuFallback overrides this to opt in when
+        any link in the chain is an AI provider.
+        """
+        from .answer_providers import AI
+
+        return isinstance(self, AI)
+
+
+class TikuFallback(Tiku):
+    """多题库回退：按配置顺序依次查询，命中即返回，未命中/类型不符则回退到下一个。
+
+    The fallback wraps an ordered list of already-configured Tiku providers.
+    `judgement_select()`/`get_submit_params()`/`COVER_RATE`/`DISABLE` are served by
+    the base class from this fallback's own config, so the consumers in
+    quiz_service / work_legacy_service treat it like any other Tiku. `query()` is
+    overridden (see below) because the per-provider validation already happens
+    inside `_query`, so the base class must NOT re-validate the chosen answer.
+    """
+
+    def __init__(self, providers=None) -> None:
+        super().__init__()
+        self.name = "多题库回退"
+        self.providers = list(providers or [])
+
+    def query(self, q_info: dict) -> str | None:
+        """Cache → chain, with the chain result taken as authoritative.
+
+        `_query` already validates each provider's answer (lenient acceptance for
+        AI/SiliconFlow links, `check_answer` for the rest). The base `Tiku.query()`
+        would re-run the strict `check_answer` here — and because ``self`` is the
+        fallback, not an AI instance, it would discard valid multi-token LLM
+        answers that a direct AI selection keeps. Overriding query() makes an
+        AI-bearing chain behave exactly like selecting that AI directly.
+        """
+        if self.DISABLE:
+            return None
+        _apply_ocr_to_title_if_needed(q_info)
+        q_info["title"] = sub(r"^\d+", "", q_info["title"])
+        q_info["title"] = sub(r"（\d+\.\d+分）$", "", q_info["title"])
+
+        cache_dao = CacheDAO()
+        cached = cache_dao.get_cache(q_info["title"])
+        if cached:
+            logger.info(f"从缓存中获取答案：{q_info['title']} -> {cached}")
+            return cached.strip()
+
+        answer = self._query(q_info)
+        if answer:
+            answer = answer.strip()
+            logger.info(f"从{self.name}获取答案：{q_info['title']} -> {answer}")
+            cache_dao.add_cache(q_info["title"], answer)
+            return answer
+        logger.error(f"从{self.name}获取答案失败：{q_info['title']}")
+        return None
+
+    @property
+    def wants_concurrent_query(self) -> bool:
+        from .answer_providers import AI
+
+        return any(isinstance(p, AI) for p in self.providers)
+
+    def _init_tiku(self):
+        # Initialize each child; silently drop any that disable themselves or
+        # fail to initialize (e.g. token-required provider with no token, or AI
+        # without endpoint/key). A mixed chain stays usable as long as one works.
+        active = []
+        for provider in self.providers:
+            try:
+                if provider._conf is None:
+                    provider.config_set(self._conf)
+                provider.init_tiku()
+                if provider.DISABLE:
+                    logger.info(f"题库 {provider.name} 不可用，已从回退链移除")
+                    continue
+                active.append(provider)
+            except Exception as e:
+                logger.error(f"初始化题库 {provider.name} 失败，已从回退链移除: {e}")
+        self.providers = active
+        if not self.providers:
+            logger.error("多题库回退初始化失败: 没有可用题库")
+            self.DISABLE = True
+        else:
+            logger.info("多题库回退已启用，查询顺序: " + " → ".join(p.name for p in self.providers))
+
+    def _query(self, q_info: dict) -> str | None:
+        # Import here to avoid a circular import with answer_providers.
+        from .answer_providers import AI, SiliconFlow
+
+        q_type = q_info.get("type")
+        for provider in self.providers:
+            try:
+                answer = provider._query(q_info)
+            except Exception as e:
+                logger.exception(f"{self.name} 查询时 {provider.name} 异常: {e}")
+                continue
+            if not answer:
+                logger.info(f"{provider.name} 未命中，回退到下一个题库")
+                continue
+            answer = answer.strip()
+
+            # Mirror Tiku.query()'s AI/SiliconFlow special-casing so a chain that
+            # ends in an LLM behaves exactly like selecting that LLM directly.
+            if isinstance(provider, (AI, SiliconFlow)):
+                if q_type == "judgement":
+                    normalized = provider._normalize_judgement_answer(answer)
+                    if normalized is None:
+                        logger.info(f"{provider.name} 判断题答案无法归一化，回退到下一个题库")
+                        continue
+                    logger.info(f"{provider.name} 命中答案")
+                    return normalized
+                logger.info(f"{provider.name} 命中答案")
+                return answer
+
+            if check_answer(answer, q_type, provider):
+                logger.info(f"{provider.name} 命中答案")
+                return answer
+            logger.info(f"{provider.name} 返回答案类型与题目类型不符，回退到下一个题库")
+        return None

--- a/backend/app/services/course/chaoxing/answer_providers/__init__.py
+++ b/backend/app/services/course/chaoxing/answer_providers/__init__.py
@@ -1,7 +1,17 @@
 from .adapter import TikuAdapter
 from .ai import AI
+from .go import TikuGo
 from .like import TikuLike
+from .local_cache import TikuLocalCache
 from .siliconflow import SiliconFlow
 from .yanxi import TikuYanxi
 
-__all__ = ["TikuYanxi", "TikuLike", "TikuAdapter", "AI", "SiliconFlow"]
+__all__ = [
+    "TikuYanxi",
+    "TikuGo",
+    "TikuLike",
+    "TikuAdapter",
+    "TikuLocalCache",
+    "AI",
+    "SiliconFlow",
+]

--- a/backend/app/services/course/chaoxing/answer_providers/go.py
+++ b/backend/app/services/course/chaoxing/answer_providers/go.py
@@ -1,0 +1,185 @@
+import re
+import threading
+import time
+
+import requests
+from loguru import logger
+
+from ..answer_base import Tiku
+
+
+class TikuGo(Tiku):
+    """GO题（网课小工具）题库实现，对接 https://q.icodef.com/wyn-nb 。
+
+    Ported from upstream Samueli924/chaoxing and adapted to this fork's
+    conventions: per-instance state (multi-tenant isolation), explicit request
+    timeouts, and loguru. A free search source — `go_authorization` is optional.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "GO题（网课小工具题库）"
+        self.api = "https://q.icodef.com/wyn-nb?v=4"
+        self._headers = {
+            "Authorization": "",
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        self._request_lock = threading.Lock()
+        self._last_request_time = 0.0
+        self._min_interval = 1.0
+        self._retry_times = 3
+        self._retry_backoff = 1.2
+        self._timeout = 15
+
+    # -- throttle ---------------------------------------------------------
+    def _sleep_for_next_request(self) -> None:
+        with self._request_lock:
+            now = time.time()
+            wait_time = max(0.0, self._last_request_time + self._min_interval - now)
+            self._last_request_time = now + wait_time
+        if wait_time > 0:
+            time.sleep(wait_time)
+
+    def _mark_request_finished(self) -> None:
+        with self._request_lock:
+            self._last_request_time = time.time()
+
+    # -- request / parse --------------------------------------------------
+    def _request_question(self, question: str, attempt: int):
+        try:
+            self._sleep_for_next_request()
+            res = requests.post(
+                self.api,
+                data={"question": question},
+                headers=self._headers,
+                timeout=self._timeout,
+            )
+            self._mark_request_finished()
+            return res
+        except requests.exceptions.RequestException as e:
+            logger.error(f"{self.name}查询异常 ({attempt}/{self._retry_times}): {e}")
+            self._mark_request_finished()
+            return None
+
+    def _parse_response(self, res):
+        if res.status_code != 200:
+            logger.error(f"{self.name}查询失败: 状态码 {res.status_code}, 响应: {res.text}")
+            return None
+        try:
+            res_json = res.json()
+        except ValueError:
+            logger.error(f"{self.name}查询失败: 返回内容不是有效JSON, 响应: {res.text}")
+            return None
+        # A valid-JSON-but-non-object body (list/str/number/null/bool) from this
+        # free third-party host must not crash the worker via res_json.get(...).
+        if not isinstance(res_json, dict):
+            logger.error(f"{self.name}查询失败: 返回结构非预期对象, 响应: {res.text}")
+            return None
+        try:
+            code = int(str(res_json.get("code", "")).strip())
+        except ValueError:
+            code = 0
+        answer = str(res_json.get("data", "")).strip()
+        msg = str(res_json.get("msg", "")).strip()
+        raw_text = f"{answer} {msg}"
+        is_throttled = any(key in raw_text for key in ["流控限制", "速度太快", "并发限制", "忙不过来"])
+        return {"code": code, "answer": answer, "msg": msg, "is_throttled": is_throttled}
+
+    def _sleep_retry(self, attempt: int, reason: str, include_min_interval: bool = False) -> None:
+        if include_min_interval:
+            sleep_seconds = max(self._min_interval, self._retry_backoff * attempt)
+        else:
+            sleep_seconds = self._retry_backoff * attempt
+        logger.warning(f"{self.name}{reason}，{sleep_seconds:.1f}s 后重试 ({attempt}/{self._retry_times})")
+        time.sleep(sleep_seconds)
+
+    @staticmethod
+    def _is_placeholder_answer(answer: str, msg: str) -> bool:
+        # GO题库 returns "李恒雅正在努力撰写中..." when it has no answer.
+        return "李恒雅" in answer or "李恒雅" in msg
+
+    # -- query ------------------------------------------------------------
+    def _query(self, q_info: dict):
+        title = q_info.get("title", "")
+        candidates = [
+            title,
+            re.sub(r"^【[^】]+】\s*", "", title).strip(),
+            re.sub(r"^\[[^\]]+\]\s*", "", title).strip(),
+        ]
+        seen = set()
+        normalized_titles = []
+        for item in candidates:
+            if item and item not in seen:
+                seen.add(item)
+                normalized_titles.append(item)
+
+        for query_title in normalized_titles:
+            answer = self._query_once(query_title)
+            if answer:
+                return answer
+        return None
+
+    def _query_once(self, question: str):
+        for attempt in range(1, self._retry_times + 1):
+            res = self._request_question(question, attempt)
+            if res is None:
+                if attempt < self._retry_times:
+                    self._sleep_retry(attempt, "查询异常", include_min_interval=True)
+                    continue
+                break
+
+            parsed = self._parse_response(res)
+            if not parsed:
+                return None
+
+            code = parsed["code"]
+            answer = parsed["answer"]
+            msg = parsed["msg"]
+            is_throttled = parsed["is_throttled"]
+
+            if code != 1:
+                if is_throttled and attempt < self._retry_times:
+                    self._sleep_retry(attempt, "触发流控")
+                    continue
+                logger.info(f"{self.name}未命中或失败: {msg or '未知错误'}")
+                return None
+
+            if not answer:
+                return None
+
+            if self._is_placeholder_answer(answer, msg):
+                if is_throttled and attempt < self._retry_times:
+                    self._sleep_retry(attempt, "命中流控提示")
+                    continue
+                return None
+
+            return answer
+
+        return None
+
+    # -- config -----------------------------------------------------------
+    def _init_tiku(self):
+        self._headers["Authorization"] = self._conf.get("go_authorization", self._headers["Authorization"])
+        try:
+            min_interval = float(self._conf.get("go_min_interval", self._min_interval))
+            if min_interval < 0:
+                raise ValueError("go_min_interval must be non-negative")
+            self._min_interval = min_interval
+        except (TypeError, ValueError):
+            logger.warning(f"{self.name}配置 go_min_interval 无效，使用默认值 {self._min_interval}")
+
+        try:
+            retry_times = int(self._conf.get("go_retry_times", self._retry_times))
+            if retry_times < 1:
+                raise ValueError("go_retry_times must be >= 1")
+            self._retry_times = retry_times
+        except (TypeError, ValueError):
+            logger.warning(f"{self.name}配置 go_retry_times 无效，使用默认值 {self._retry_times}")
+
+        try:
+            retry_backoff = float(self._conf.get("go_retry_backoff", self._retry_backoff))
+            if retry_backoff < 0:
+                raise ValueError("go_retry_backoff must be non-negative")
+            self._retry_backoff = retry_backoff
+        except (TypeError, ValueError):
+            logger.warning(f"{self.name}配置 go_retry_backoff 无效，使用默认值 {self._retry_backoff}")

--- a/backend/app/services/course/chaoxing/answer_providers/local_cache.py
+++ b/backend/app/services/course/chaoxing/answer_providers/local_cache.py
@@ -1,0 +1,19 @@
+from ..answer_base import Tiku
+
+
+class TikuLocalCache(Tiku):
+    """本地缓存题库：只复用进程级答案缓存，从不调用外部题库 API。
+
+    `Tiku.query()` always consults the shared answer cache first, so a provider
+    whose `_query` returns None effectively answers from cache only. This makes
+    the "本地缓存 / LocalCache" option in the frontend a real, token-free choice
+    (e.g. as the first link in a fallback chain) instead of a dead value.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "本地缓存题库"
+
+    def _query(self, q_info: dict):
+        # Never hit the network; cache is handled by the base Tiku.query().
+        return None

--- a/backend/app/services/course/chaoxing/quiz_service.py
+++ b/backend/app/services/course/chaoxing/quiz_service.py
@@ -7,7 +7,6 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import requests
 from loguru import logger
 
-from .answer import AI
 from .answer_check import cut
 from .decode import decode_questions_info
 from .exceptions import MaxRetryExceeded
@@ -229,7 +228,7 @@ class QuizAnswerProcessor:
         total_questions = len(questions["questions"])
         found_answers = 0
 
-        if isinstance(self.tiku, AI):
+        if self.tiku.wants_concurrent_query:
             lock = threading.Lock()
 
             def inc_found_concurrent():

--- a/backend/app/services/course/chaoxing/work_legacy_service.py
+++ b/backend/app/services/course/chaoxing/work_legacy_service.py
@@ -8,7 +8,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from loguru import logger
 
-from .answer import AI, Tiku
+from .answer import Tiku
 from .answer_check import cut
 from .decode import decode_questions_info
 from .exceptions import MaxRetryExceeded
@@ -324,8 +324,8 @@ class ChaoxingWorkLegacyService:
         total_questions = len(questions["questions"])
         found_answers = 0
 
-        # 若使用 AI 题库，则在同一张卷内并发搜题
-        if isinstance(self.tiku, AI):
+        # 若题库含 AI（含 AI 回退链），则在同一张卷内并发搜题
+        if self.tiku.wants_concurrent_query:
             lock = threading.Lock()
 
             def inc_found_concurrent():

--- a/backend/tests/unit/test_tiku_go_and_fallback.py
+++ b/backend/tests/unit/test_tiku_go_and_fallback.py
@@ -1,0 +1,447 @@
+"""Tests for the ported GO题库 (TikuGo), the multi-题库 fallback chain
+(TikuFallback), the LocalCache provider, and the CSV-aware tiku factory.
+
+Brings the answer module to parity with upstream Samueli924/chaoxing while
+respecting this fork's per-instance multi-tenant isolation and AI judgement
+normalization.
+"""
+
+from unittest.mock import patch
+
+
+class FakeResp:
+    def __init__(self, json_data, status=200):
+        self._j = json_data
+        self.status_code = status
+        self.text = str(json_data)
+
+    def json(self):
+        return self._j
+
+
+# ---------------------------------------------------------------------------
+# TikuGo — GO题库 (网课小工具, q.icodef.com)
+# ---------------------------------------------------------------------------
+
+
+def _q(title="中国的首都是哪里？", qtype="single", options="A.北京\nB.上海"):
+    return {"title": title, "type": qtype, "options": options}
+
+
+def test_tikugo_hit_returns_answer():
+    from app.services.course.chaoxing.answer_providers import TikuGo
+
+    go = TikuGo()
+    with patch(
+        "app.services.course.chaoxing.answer_providers.go.requests.post",
+        return_value=FakeResp({"code": 1, "data": "北京", "msg": ""}),
+    ):
+        assert go._query(_q()) == "北京"
+
+
+def test_tikugo_miss_returns_none():
+    from app.services.course.chaoxing.answer_providers import TikuGo
+
+    go = TikuGo()
+    with patch(
+        "app.services.course.chaoxing.answer_providers.go.requests.post",
+        return_value=FakeResp({"code": 0, "data": "", "msg": "未找到"}),
+    ):
+        assert go._query(_q()) is None
+
+
+def test_tikugo_placeholder_answer_discarded():
+    """GO题库 returns '李恒雅正在努力撰写中...' as a not-found placeholder."""
+    from app.services.course.chaoxing.answer_providers import TikuGo
+
+    go = TikuGo()
+    with patch(
+        "app.services.course.chaoxing.answer_providers.go.requests.post",
+        return_value=FakeResp({"code": 1, "data": "李恒雅正在努力撰写中", "msg": ""}),
+    ):
+        assert go._query(_q()) is None
+
+
+def test_tikugo_throttle_then_success():
+    from app.services.course.chaoxing.answer_providers import TikuGo
+
+    go = TikuGo()
+    responses = [
+        FakeResp({"code": 0, "data": "", "msg": "流控限制，请稍后"}),
+        FakeResp({"code": 1, "data": "北京", "msg": ""}),
+    ]
+    with (
+        patch("app.services.course.chaoxing.answer_providers.go.time.sleep"),
+        patch("app.services.course.chaoxing.answer_providers.go.requests.post", side_effect=responses),
+    ):
+        assert go._query(_q()) == "北京"
+
+
+def test_tikugo_strips_bracket_prefix_and_hits():
+    """The raw 【...】-prefixed title must MISS so only the stripped title can HIT,
+    proving the prefix-stripping path is load-bearing."""
+    from app.services.course.chaoxing.answer_providers import TikuGo
+
+    go = TikuGo()
+    responses = [
+        FakeResp({"code": 0, "data": "", "msg": "未找到"}),  # raw "【单选题】..." misses
+        FakeResp({"code": 1, "data": "北京", "msg": ""}),  # stripped title hits
+    ]
+    with (
+        patch("app.services.course.chaoxing.answer_providers.go.time.sleep"),
+        patch("app.services.course.chaoxing.answer_providers.go.requests.post", side_effect=responses) as post,
+    ):
+        assert go._query(_q(title="【单选题】中国的首都是哪里？")) == "北京"
+        assert post.call_count == 2
+        assert post.call_args_list[1].kwargs["data"] == {"question": "中国的首都是哪里？"}
+
+
+def test_tikugo_non_dict_json_returns_none():
+    """A valid-JSON-but-non-object body must not crash; it is treated as a miss."""
+    from app.services.course.chaoxing.answer_providers import TikuGo
+
+    go = TikuGo()
+    for body in (["x"], "oops", 42, None, True):
+        with patch("app.services.course.chaoxing.answer_providers.go.requests.post", return_value=FakeResp(body)):
+            assert go._query(_q()) is None
+
+
+def test_tikugo_init_applies_config():
+    from app.services.course.chaoxing.answer_providers import TikuGo
+
+    go = TikuGo()
+    go.config_set(
+        {
+            "provider": "TikuGo",
+            "go_authorization": "tok",
+            "go_min_interval": "2.5",
+            "go_retry_times": "5",
+            "go_retry_backoff": "0.5",
+        }
+    )
+    go.init_tiku()
+    assert go._headers["Authorization"] == "tok"
+    assert go._min_interval == 2.5
+    assert go._retry_times == 5
+    assert go._retry_backoff == 0.5
+
+
+def test_tikugo_init_invalid_values_keep_defaults():
+    from app.services.course.chaoxing.answer_providers import TikuGo
+
+    go = TikuGo()
+    go.config_set(
+        {
+            "provider": "TikuGo",
+            "go_retry_times": "0",
+            "go_min_interval": "-1",
+            "go_retry_backoff": "abc",
+        }
+    )
+    go.init_tiku()
+    assert go._min_interval == 1.0
+    assert go._retry_times == 3
+    assert go._retry_backoff == 1.2
+    assert go._headers["Authorization"] == ""  # go_authorization optional
+
+
+# ---------------------------------------------------------------------------
+# TikuFallback — 多题库回退
+# ---------------------------------------------------------------------------
+
+
+def _fake_provider(answer, name="fake"):
+    from app.services.course.chaoxing.answer_base import Tiku
+
+    class FakeProvider(Tiku):
+        def __init__(self):
+            super().__init__()
+            self.name = name
+            self.true_list = ["正确"]
+            self.false_list = ["错误"]
+            self.calls = 0
+
+        def _query(self, q_info):
+            self.calls += 1
+            return answer
+
+    return FakeProvider()
+
+
+def test_fallback_first_hit_wins():
+    from app.services.course.chaoxing.answer_base import TikuFallback
+
+    p1 = _fake_provider("A", "p1")
+    p2 = _fake_provider("B", "p2")
+    fb = TikuFallback([p1, p2])
+    fb.DISABLE = False
+    assert fb._query(_q()) == "A"
+    assert p2.calls == 0  # second provider must not be consulted on a hit
+
+
+def test_fallback_falls_through_on_miss():
+    from app.services.course.chaoxing.answer_base import TikuFallback
+
+    p1 = _fake_provider(None, "p1")
+    p2 = _fake_provider("B", "p2")
+    fb = TikuFallback([p1, p2])
+    fb.DISABLE = False
+    assert fb._query(_q()) == "B"
+    assert p1.calls == 1 and p2.calls == 1
+
+
+def test_fallback_falls_through_on_type_mismatch():
+    from app.services.course.chaoxing.answer_base import TikuFallback
+
+    # A judgement answer that is neither 正确 nor 错误 fails check_answer → fall through.
+    p1 = _fake_provider("一段废话", "p1")
+    p2 = _fake_provider("正确", "p2")
+    fb = TikuFallback([p1, p2])
+    fb.DISABLE = False
+    assert fb._query(_q(qtype="judgement")) == "正确"
+
+
+def test_fallback_ai_judgement_is_normalized():
+    from app.services.course.chaoxing.answer_base import TikuFallback
+    from app.services.course.chaoxing.answer_providers import AI
+
+    ai = AI()
+    ai.true_list = ["正确"]
+    ai.false_list = ["错误"]
+    ai._query = lambda q_info: "这道题表述是对的"
+    fb = TikuFallback([ai])
+    fb.DISABLE = False
+    assert fb._query(_q(qtype="judgement")) == "正确"
+
+
+def test_fallback_ai_non_judgement_accepts_any_nonempty():
+    from app.services.course.chaoxing.answer_base import TikuFallback
+    from app.services.course.chaoxing.answer_providers import AI
+
+    ai = AI()
+    ai._query = lambda q_info: "输入/输出"
+    fb = TikuFallback([ai])
+    fb.DISABLE = False
+    assert fb._query(_q(qtype="completion")) == "输入/输出"
+
+
+def test_fallback_all_miss_returns_none():
+    from app.services.course.chaoxing.answer_base import TikuFallback
+
+    fb = TikuFallback([_fake_provider(None, "p1"), _fake_provider(None, "p2")])
+    fb.DISABLE = False
+    assert fb._query(_q()) is None
+
+
+def test_fallback_falls_through_on_query_exception():
+    """A provider that raises AT QUERY TIME must be swallowed and the chain
+    continues (the core resilience guarantee of the fallback)."""
+    from app.services.course.chaoxing.answer_base import Tiku, TikuFallback
+
+    class Raiser(Tiku):
+        def __init__(self):
+            super().__init__()
+            self.name = "raiser"
+            self.calls = 0
+
+        def _query(self, q_info):
+            self.calls += 1
+            raise RuntimeError("net")
+
+    raiser = Raiser()
+    ok = _fake_provider("B", "ok")
+    fb = TikuFallback([raiser, ok])
+    fb.DISABLE = False
+    assert fb._query(_q()) == "B"
+    assert raiser.calls == 1 and ok.calls == 1
+
+
+def test_fallback_query_keeps_multitoken_single_ai_answer():
+    """Through the PUBLIC query() (what consumers call), a chain ending in AI must
+    keep a valid multi-token single-choice answer — base query() must NOT re-run
+    strict check_answer on a fallback result. Regression guard for the double-
+    validation bug."""
+    from app.services.course.chaoxing.answer_base import TikuFallback
+    from app.services.course.chaoxing.answer_providers import AI
+
+    ai = AI()
+    ai.true_list = ["正确"]
+    ai.false_list = ["错误"]
+    ai._query = lambda q_info: "Babbage machine"
+    fb = TikuFallback([ai])
+    fb.DISABLE = False
+    with (
+        patch("app.services.course.chaoxing.answer_base.CacheDAO.get_cache", return_value=None),
+        patch("app.services.course.chaoxing.answer_base.CacheDAO.add_cache"),
+    ):
+        assert fb.query(_q(qtype="single")) == "Babbage machine"
+
+
+def test_fallback_init_drops_disabled_provider():
+    """A provider that disables itself during init WITHOUT raising (e.g. a
+    token-less TikuLike) must be dropped from the chain."""
+    from app.services.course.chaoxing.answer_base import Tiku, TikuFallback
+    from app.services.course.chaoxing.answer_providers import TikuLocalCache
+
+    class QuietDisable(Tiku):
+        def __init__(self):
+            super().__init__()
+            self.name = "quietdisable"
+
+        def _init_tiku(self):
+            self.DISABLE = True  # disables itself WITHOUT raising
+
+        def _query(self, q_info):
+            return None
+
+    ok = TikuLocalCache()
+    fb = TikuFallback([QuietDisable(), ok])
+    fb.config_set({"provider": "x"})
+    fb.init_tiku()
+    assert fb.DISABLE is False
+    assert fb.providers == [ok]
+
+
+def test_wants_concurrent_query():
+    """Only AI (directly or as a link in a chain) opts into concurrent answering."""
+    from app.services.course.chaoxing.answer_base import TikuFallback
+    from app.services.course.chaoxing.answer_providers import AI, SiliconFlow, TikuGo, TikuLocalCache
+
+    assert AI().wants_concurrent_query is True
+    assert SiliconFlow().wants_concurrent_query is False
+    assert TikuGo().wants_concurrent_query is False
+    assert TikuFallback([TikuGo(), AI()]).wants_concurrent_query is True
+    assert TikuFallback([TikuGo(), TikuLocalCache()]).wants_concurrent_query is False
+
+
+def test_fallback_init_drops_failing_provider():
+    from app.services.course.chaoxing.answer_base import Tiku, TikuFallback
+    from app.services.course.chaoxing.answer_providers import TikuLocalCache
+
+    class FailInit(Tiku):
+        def __init__(self):
+            super().__init__()
+            self.name = "failinit"
+
+        def _init_tiku(self):
+            raise ValueError("boom")
+
+        def _query(self, q_info):
+            return None
+
+    ok = TikuLocalCache()
+    fb = TikuFallback([FailInit(), ok])
+    fb.config_set({"provider": "x"})
+    fb.init_tiku()
+    assert fb.DISABLE is False
+    assert fb.providers == [ok]
+
+
+def test_fallback_all_init_fail_disables():
+    from app.services.course.chaoxing.answer_base import Tiku, TikuFallback
+
+    class FailInit(Tiku):
+        def __init__(self):
+            super().__init__()
+            self.name = "failinit"
+
+        def _init_tiku(self):
+            raise ValueError("boom")
+
+        def _query(self, q_info):
+            return None
+
+    fb = TikuFallback([FailInit(), FailInit()])
+    fb.config_set({"provider": "x"})
+    fb.init_tiku()
+    assert fb.DISABLE is True
+
+
+# ---------------------------------------------------------------------------
+# Factory — CSV provider parsing
+# ---------------------------------------------------------------------------
+
+
+def _factory(provider):
+    from app.services.course.chaoxing.answer_base import Tiku
+
+    t = Tiku()
+    t.config_set({"provider": provider})
+    return t.get_tiku_from_config()
+
+
+def test_factory_single_localcache():
+    from app.services.course.chaoxing.answer_providers import TikuLocalCache
+
+    r = _factory("LocalCache")
+    assert isinstance(r, TikuLocalCache)
+    assert r.DISABLE is False
+
+
+def test_factory_single_tikugo():
+    from app.services.course.chaoxing.answer_providers import TikuGo
+
+    assert isinstance(_factory("TikuGo"), TikuGo)
+
+
+def test_factory_csv_builds_fallback_chain():
+    from app.services.course.chaoxing.answer_base import TikuFallback
+    from app.services.course.chaoxing.answer_providers import TikuGo, TikuLocalCache
+
+    r = _factory("LocalCache,TikuGo")
+    assert isinstance(r, TikuFallback)
+    assert [type(p) for p in r.providers] == [TikuLocalCache, TikuGo]
+
+
+def test_factory_unknown_provider_disables():
+    assert _factory("Nope").DISABLE is True
+
+
+def test_factory_csv_with_unknown_disables():
+    assert _factory("LocalCache,Nope").DISABLE is True
+
+
+def test_factory_empty_provider_disables():
+    # Frontend sends '' when all 题库 are deselected ([].join(',')).
+    assert _factory("").DISABLE is True
+
+
+def test_factory_whitespace_or_comma_only_disables():
+    # Exercises the `if not names` branch in get_tiku_from_config.
+    assert _factory("   ").DISABLE is True
+    assert _factory(",").DISABLE is True
+
+
+# ---------------------------------------------------------------------------
+# TikuLocalCache — 本地缓存题库
+# ---------------------------------------------------------------------------
+
+
+def test_localcache_query_always_none():
+    from app.services.course.chaoxing.answer_providers import TikuLocalCache
+
+    assert TikuLocalCache()._query(_q()) is None
+
+
+def test_localcache_serves_cached_answer():
+    from app.services.course.chaoxing.answer_providers import TikuLocalCache
+
+    lc = TikuLocalCache()
+    lc.config_set({"provider": "LocalCache"})
+    lc.init_tiku()
+    # Patch where query() actually looks it up (answer_base's bound CacheDAO),
+    # which is robust even if another test reloaded the answer_cache module.
+    with patch("app.services.course.chaoxing.answer_base.CacheDAO.get_cache", return_value="已缓存答案"):
+        assert lc.query(_q()) == "已缓存答案"
+
+
+def test_localcache_uncached_returns_none():
+    from app.services.course.chaoxing.answer_providers import TikuLocalCache
+
+    lc = TikuLocalCache()
+    lc.config_set({"provider": "LocalCache"})
+    lc.init_tiku()
+    # Patch where query() actually looks it up (answer_base's bound CacheDAO),
+    # which is robust even if another test reloaded the answer_cache module.
+    with patch("app.services.course.chaoxing.answer_base.CacheDAO.get_cache", return_value=None):
+        assert lc.query(_q()) is None

--- a/docs/superpowers/specs/2026-06-24-tiku-go-and-fallback-design.md
+++ b/docs/superpowers/specs/2026-06-24-tiku-go-and-fallback-design.md
@@ -1,0 +1,127 @@
+# 题库功能补全：GO 题库 + 多题库回退 + LocalCache 修复
+
+**Date:** 2026-06-24
+**Branch:** `feat/tiku-go-and-fallback`
+**Upstream reference:** [Samueli924/chaoxing](https://github.com/Samueli924/chaoxing) `api/answer.py`
+
+## Background
+
+本项目的超星答题 (题库) 模块 fork 自 Samueli924/chaoxing 的 `api/answer.py`，
+但落后于上游：上游 `PROVIDER_REGISTRY` 含 `TikuYanxi / TikuGo / TikuLike /
+TikuAdapter / AI / SiliconFlow` 并支持 `TikuFallback` 多题库链式回退
+(`provider = TikuYanxi,TikuGo,AI`)，而本 fork 只有 5 个 provider 且工厂只支持
+单一 provider。此外前端 `ConfigSection.jsx` 已经列出「本地缓存 / LocalCache」
+选项，但后端工厂没有注册它 —— 选中后会因「未知的题库 provider」静默禁用题库。
+
+这就是「题库功能不完整」的具体含义。
+
+## Goals
+
+1. **GO 题库 (`TikuGo`)** —— 移植上游免费搜题源 (网课小工具, `q.icodef.com`)，
+   适配本 fork 的重构包结构与多租户实例隔离约定。
+2. **多题库回退 (`TikuFallback`)** —— `provider` 支持逗号分隔的多个题库，
+   按顺序兜底；某题库未命中/类型不符则回退到下一个。
+3. **LocalCache 修复** —— 新增 `TikuLocalCache` 并注册为 `LocalCache`，
+   让已存在的前端「本地缓存」选项真正生效（只用已缓存答案，不调外部 API）。
+4. **前端** —— 题库选择改为多选 + 顺序回退（序号徽标），新增「GO 题库」。
+5. **文档** —— 在 `README.md` / `README.zh-CN.md` 各加一节「题库来源」。
+6. **交付** —— feature 分支跑通测试后开 PR 至 `sweetcornna/university-helper:main`。
+
+## Non-goals
+
+- 不动单一 provider 的 AI/SiliconFlow 既有行为（缺 key 仍按现状报错——预存在问题，超出范围）。
+- 不引入离线题库数据语料。
+- 不做前端题库选择之外的 UX 重构。
+
+## Architecture
+
+复用现有结构，不重构既有边界：
+
+| 单元 | 职责 | 依赖 |
+|------|------|------|
+| `answer_providers/go.py :: TikuGo` | GO 题库查询（节流+重试+占位答案识别） | `Tiku`、`requests` |
+| `answer_providers/local_cache.py :: TikuLocalCache` | 只读缓存题库（`_query` 恒返回 None） | `Tiku` |
+| `answer_base.py :: TikuFallback` | 按序包裹多个 provider，逐个兜底 | `check_answer`、运行时导入 `AI/SiliconFlow` |
+| `answer_base.py :: get_tiku_from_config` | 解析 CSV `provider` → 单题库 / 回退链 | provider 注册表 |
+| `payload_mapper.py :: normalize_tiku_config` | CSV provider 的 token 门控 + 透传 `go_authorization` | — |
+| `ConfigSection.jsx` / `useTaskConfig.js` / `ChaoxingFanya.jsx` | 多选题库 UI → CSV `provider` | — |
+
+### TikuGo 适配要点
+
+- 实例属性（多租户隔离），非类属性。
+- `requests` 全部带 `timeout=`，用 `loguru` logger，不用 `verify=False`。
+- 保留：每请求最小间隔节流、429/流控重试退避、`q.icodef.com` 的
+  `code != 1`/占位答案 (「李恒雅正在努力撰写中」) 识别、标题前缀剥离重试。
+- `_init_tiku` 从 `self._conf` 读 `go_authorization`（可选）、`go_min_interval`
+  /`go_retry_times`/`go_retry_backoff`（带默认与校验）。
+
+### TikuFallback 语义（关键正确性点）
+
+`_query` 按序遍历子 provider：
+
+```
+for provider in self.providers:
+    answer = provider._query(q_info)          # try/except 包裹，异常→下一个
+    if not answer: continue
+    answer = answer.strip()
+    # 与 base.query() 的 AI/SiliconFlow 特例保持一致：
+    if isinstance(provider, (AI, SiliconFlow)):
+        if q_info type == judgement:
+            n = provider._normalize_judgement_answer(answer)
+            if n is None: continue
+            return n
+        return answer                         # AI 非判断题：非空即采纳
+    if check_answer(answer, q_info['type'], provider):
+        return answer                         # 普通题库：类型校验通过才采纳
+    # 类型不符 → 回退下一个
+return None
+```
+
+- `_init_tiku` 对每个子 provider 调 `init_tiku()`，**try/except 丢弃初始化失败者**
+  （如缺 token 的 TikuYanxi、缺 key 的 AI），全部失败则 `self.DISABLE = True`。
+  这天然让「共享单 token + 混合链」健壮：能用的留下，不能用的丢掉。
+- 缓存由外层 `TikuFallback.query()`（基类）统一写入一次，子 provider 用 `_query`
+  绕过各自缓存，避免重复写。
+- 暴露消费者用到的全部字段：`DISABLE / COVER_RATE / true_list / false_list /
+  judgement_select / get_submit_params`（均由基类 `init_tiku` 从 config 设置）。
+
+### 工厂 CSV 解析
+
+`get_tiku_from_config`：把 `provider` 按 `,` 拆分、去空白；空→禁用；
+含未知名→禁用并报错；单个→返回该 provider 实例（保持今日行为）；
+多个→构造 `TikuFallback(chain)`。`_provider_map` 增加
+`TikuGo`、`LocalCache`(→`TikuLocalCache`)。
+
+### 前端多选回退
+
+- `useTaskConfig`: `tikuProvider` 由字符串改为数组，默认 `['TikuYanxi']`。
+- `ConfigSection`: 题库 pills 改为多选，点击 toggle 成员，选中顺序=回退顺序，
+  选中 pill 上显示 ①②③ 序号；新增 `{ value: 'TikuGo', label: 'GO 题库',
+  hint: '免费搜题源' }`。
+- `ChaoxingFanya.jsx`: `provider: taskConfig.tikuProvider.join(',')`。
+
+## Error handling
+
+- 子题库网络异常/超时：捕获并回退下一个，不中断整卷。
+- 子题库初始化异常：丢弃该子题库（见上）。
+- 全链不可用：`DISABLE=True`，与「未配置题库」一致地静默跳过答题。
+
+## Testing (TDD)
+
+后端单测扩展 `tests/unit/test_answer_cache_and_tiku.py`（或新增
+`test_tiku_go_and_fallback.py`）：
+
+1. `TikuGo`：命中、未命中(code!=1)、占位答案被丢弃、流控重试、标题前缀剥离。
+2. `TikuFallback`：首个命中即返回；首个未命中→回退；类型不符→回退；
+   链尾 AI 判断题经 `_normalize_judgement_answer` 归一化；全部失败→None；
+   `_init_tiku` 丢弃失败子题库；无可用→DISABLE。
+3. 工厂：单 provider 不变；CSV→TikuFallback；含未知名→DISABLE；
+   `LocalCache`/`TikuGo` 可解析。
+4. `TikuLocalCache`：命中缓存返回、未缓存返回 None、`_query` 恒 None。
+5. `payload_mapper`：CSV provider 不被单 provider token 门控误删；`go_authorization` 透传。
+
+全套 `pytest` + 前端 `vitest` + `ruff` 必须绿。实现后用多 agent 工作流对 diff 做对抗式审查。
+
+## Delivery
+
+`feat/tiku-go-and-fallback` → 测试全绿 → push → PR vs `main`（README 一节说明）。

--- a/frontend/src/pages/ChaoxingFanya.jsx
+++ b/frontend/src/pages/ChaoxingFanya.jsx
@@ -136,7 +136,11 @@ export default function ChaoxingFanya() {
           concurrency: taskConfig.concurrency,
           unopened_strategy: taskConfig.unopenedStrategy,
           tiku_config: {
-            provider: taskConfig.tikuProvider,
+            // Ordered providers → comma-separated `provider` (单题库 or 回退链).
+            provider: (Array.isArray(taskConfig.tikuProvider)
+              ? taskConfig.tikuProvider
+              : [taskConfig.tikuProvider]
+            ).join(','),
             token: taskConfig.tikuToken.trim(),
             coverage_threshold: taskConfig.coverageThreshold,
             judge_mapping: {

--- a/frontend/src/pages/chaoxing-fanya/components/ConfigSection.jsx
+++ b/frontend/src/pages/chaoxing-fanya/components/ConfigSection.jsx
@@ -15,8 +15,9 @@ const SUBMIT_MODES = [
 // is kept as a sub-label so it stays unambiguous, but the cryptic identifiers
 // no longer face the student directly.
 const TIKU_PROVIDERS = [
-  { value: 'TikuYanxi', label: '言溪题库', hint: '通用题库', recommended: true },
-  { value: 'TikuLike', label: 'Like 题库', hint: '备用题库' },
+  { value: 'TikuYanxi', label: '言溪题库', hint: '通用题库（需 Token）', recommended: true },
+  { value: 'TikuGo', label: 'GO 题库', hint: '免费搜题源' },
+  { value: 'TikuLike', label: 'Like 题库', hint: '备用题库（需 Token）' },
   { value: 'TikuAdapter', label: '题库适配器', hint: '自定义适配' },
   { value: 'AI', label: 'AI 智能答题', hint: '无匹配时由 AI 作答' },
   { value: 'SiliconFlow', label: '硅基流动', hint: 'AI 服务（需 Token）' },
@@ -63,6 +64,65 @@ function PillGroup({ label, options, value, onChange }) {
           )
         })}
       </div>
+    </div>
+  )
+}
+
+// Ordered multi-select pill group. `value` is an array of selected option
+// values in fallback order; clicking toggles membership (append on select,
+// remove on deselect). Selected pills show their ①②③ position so the user can
+// see the 多题库回退 order at a glance.
+function MultiPillGroup({ label, options, value, onChange, hint }) {
+  const toggle = (optValue) => {
+    if (value.includes(optValue)) {
+      onChange(value.filter((item) => item !== optValue))
+    } else {
+      onChange([...value, optValue])
+    }
+  }
+  const CIRCLED = ['①', '②', '③', '④', '⑤', '⑥', '⑦', '⑧', '⑨']
+  return (
+    <div role="group" aria-label={label}>
+      <span className="mb-2 block text-sm font-medium text-text/80">{label}</span>
+      <div className="flex flex-wrap gap-2">
+        {options.map((opt) => {
+          const order = value.indexOf(opt.value)
+          const active = order >= 0
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              aria-pressed={active}
+              onClick={() => toggle(opt.value)}
+              className={`flex flex-col items-start rounded-xl border px-4 py-2 text-sm font-medium transition-all duration-200 cursor-pointer ${
+                active
+                  ? 'border-transparent bg-primary text-white shadow-md'
+                  : 'border-border bg-surface text-text/70 hover:border-border hover:bg-surface-hover'
+              }`}
+            >
+              <span className="flex items-center gap-1.5">
+                {active && <span className="text-xs">{CIRCLED[order] || `(${order + 1})`}</span>}
+                {opt.label}
+                {opt.recommended && (
+                  <span
+                    className={`rounded-full px-1.5 py-0.5 text-[10px] ${
+                      active ? 'bg-surface/20 text-white' : 'bg-success-surface text-success'
+                    }`}
+                  >
+                    推荐
+                  </span>
+                )}
+              </span>
+              {opt.hint && (
+                <span className={`text-[11px] ${active ? 'text-white/70' : 'text-text-muted'}`}>
+                  {opt.hint}
+                </span>
+              )}
+            </button>
+          )
+        })}
+      </div>
+      {hint && <p className="mt-2 text-xs text-text-muted">{hint}</p>}
     </div>
   )
 }
@@ -150,11 +210,12 @@ export default function ConfigSection({
         </summary>
 
         <div className="mt-4 space-y-4">
-          <PillGroup
-            label="题库来源"
+          <MultiPillGroup
+            label="题库来源（可多选，按点击顺序回退）"
             options={TIKU_PROVIDERS}
             value={tikuProvider}
             onChange={setTikuProvider}
+            hint="可选多个题库：前一个未命中时自动回退到下一个。例如「言溪 → GO 题库」。"
           />
 
           <div>

--- a/frontend/src/pages/chaoxing-fanya/hooks/useTaskConfig.js
+++ b/frontend/src/pages/chaoxing-fanya/hooks/useTaskConfig.js
@@ -13,7 +13,12 @@ export default function useTaskConfig() {
   const [unopenedStrategy, setUnopenedStrategy] = useState('retry')
 
 
-  const [tikuProvider, setTikuProvider] = useState('TikuYanxi')
+  // Ordered list of answer-bank providers; sent to the backend as a
+  // comma-separated `provider` (单个=单题库，多个=按顺序回退). Default chain:
+  // 言溪 first (best, if a token is set), then the free GO题库 — so 答题 still
+  // works without a Token. (The shared answer cache is always consulted first,
+  // so adding 本地缓存 as an extra link would be redundant.)
+  const [tikuProvider, setTikuProvider] = useState(['TikuYanxi', 'TikuGo'])
 
 
   const [tikuToken, setTikuToken] = useState('')


### PR DESCRIPTION
## 背景

本项目的超星答题「题库」模块 fork 自上游 [Samueli924/chaoxing](https://github.com/Samueli924/chaoxing) 的 `api/answer.py`，但落后于上游：上游支持 **GO 题库（`TikuGo`）** 这个免费搜题源，以及 **多题库回退（`TikuFallback`）**（`provider` 配多个题库按顺序兜底）；本 fork 都没有。此外前端早已列出「本地缓存 / `LocalCache`」选项，但后端工厂没注册它 —— 选中后会因「未知的题库 provider」**静默禁用答题**。这就是「题库功能不完整」的具体表现。

## 本 PR 做了什么

### 后端
- **`TikuGo`**（`answer_providers/go.py`）—— 移植上游免费 GO 题库（网课小工具，`q.icodef.com`），适配本 fork 的**按实例隔离**（多租户）、显式 `timeout=`、loguru 约定，保留节流/重试/占位答案识别/标题前缀剥离。对**非 dict 的合法 JSON 响应**做了防护，第三方返回畸形结构也不会让整张卷崩溃。
- **`TikuFallback`**（`answer_base.py`）—— `tiku_config.provider` 现支持**逗号分隔的有序列表**，前一个未命中/类型不符则回退下一个。初始化失败的题库（缺 Token 的题库、缺 key 的大模型）会**自动从回退链剔除**，混合链只要有一个可用就仍有效。
  - 重写了 `query()`，使每个子题库在 `_query` 里已完成的校验成为**最终结论**——基类不再二次 `check_answer`，因此**链尾是大模型时，行为与直接选该大模型完全一致**（包括 `wants_concurrent_query` 暴露的整卷并发搜题路径）。
- **`LocalCache`**（`answer_providers/local_cache.py`）—— 注册前端早已提供的「本地缓存」纯缓存题库（不调外部 API），修复其断链。
- 工厂 `get_tiku_from_config` 支持 CSV 解析（单个=单题库，多个=回退链；含未知名/空=安全禁用）。

### 前端
- 「题库来源」改为**有序多选**（选中顺序=回退顺序，①②③ 序号徽标），新增 **GO 题库** pill。
- 默认链 **言溪 → GO 题库**，即使没有 Token 也能答题（言溪需 Token 时自动回退到免费的 GO 题库）。

### 文档
- `README.md` / `README.zh-CN.md` 各加一节 **Answer banks（题库）**：列出全部题库来源、是否需要 Token、如何配置回退链。
- `CHANGELOG.md`、设计 spec（`docs/superpowers/specs/`）。

## 质量保障
- **测试先行（TDD）**：30 个新单测（TikuGo 命中/未命中/占位/流控重试/前缀剥离/非 dict 防护/init 配置；TikuFallback 首命中/回退/类型不符/AI 归一化/异常回退/init 丢弃/全失败禁用/`query()` 保留多 token AI 答案/并发判定；工厂 CSV/未知/空白；LocalCache）。
- 后端 CI 等效套件 **279 passed**（`--ignore=tests/performance`）；前端 **47 passed**，`eslint --max-warnings 0` 清零，`vite build` 通过；后端 `ruff check`/`ruff format --check` 全过。
- 经过一轮**多 agent 对抗式代码评审**（5 个维度 → 每条发现独立复核），确认的 12 条全部已修复或补测，其中 2 条高危生产 bug（链尾 AI 答案被二次校验丢弃、TikuGo 非 dict 响应崩溃）已修。

🤖 Generated with [Claude Code](https://claude.com/claude-code)